### PR TITLE
correction d'un bug dans le nommage des thumbnails

### DIFF
--- a/pod_project/core/utils.py
+++ b/pod_project/core/utils.py
@@ -358,8 +358,8 @@ def add_thumbnails(video_id, in_w, in_h, folder):
             if DEBUG:
                 print "THUMBNAILS %s" % i
             upc_image, created = Image.objects.get_or_create(
-                folder=folder, name="%s_%s.png" % (video.slug, i))
-            upc_image.file.save("%s_%s.png" % (video.slug, i), File(
+                folder=folder, name="%s_%s.png" % (video.id, i))
+            upc_image.file.save("%s_%s.png" % (video.id, i), File(
                 open("%s_%s.png" % (tempfile.name, i))), save=True)
             upc_image.owner = video.owner
             upc_image.save()

--- a/pod_project/core/utils.py
+++ b/pod_project/core/utils.py
@@ -358,8 +358,8 @@ def add_thumbnails(video_id, in_w, in_h, folder):
             if DEBUG:
                 print "THUMBNAILS %s" % i
             upc_image, created = Image.objects.get_or_create(
-                folder=folder, name="%s_%s.png" % (video.id, i))
-            upc_image.file.save("%s_%s.png" % (video.id, i), File(
+                folder=folder, name="%d_%s.png" % (video.id, i))
+            upc_image.file.save("%d_%s.png" % (video.id, i), File(
                 open("%s_%s.png" % (tempfile.name, i))), save=True)
             upc_image.owner = video.owner
             upc_image.save()


### PR DESCRIPTION
Cela pouvait bloquer le processus d'encodage d'une vidéo quand le titre était trop long.

J'ai mis `video.id` plutôt que le `video.slug[:180]` parce que j'avais toujours, dans certains cas, une entrée qui manquait dans la table **easy_thumbnails_thumbnail**, et même si ça n'avait apparamment pas une grande importance, j'ai préféré la jouer safe (et ça m'a paru plus logique que de trouver une autre valeur arbitraire plus basse).

Tu me dis s'il y a un qqch qui ne convient pas (et désolé pour le retard) :-)