### PR TITLE
Feature: selecting “draft” checkbox hides “restricted” and “password” inputs in video edit template.

### DIFF
--- a/pod_project/core/static/JS/main.js
+++ b/pod_project/core/static/JS/main.js
@@ -1,3 +1,4 @@
+
 $(document).ready(function() {
     // Lancement de la recherche au clic sur le bouton de recherche
     $(document.body).on(
@@ -10,3 +11,42 @@ $(document).ready(function() {
         }
     );
 });
+
+
+
+( function( POD, $, undefined ) { 'use strict';
+
+
+    /*
+        Video creation / edition:
+
+            - selecting “Draft” hides “Restricted access” and “Password”
+
+    */
+    POD.setVideoEditForm = function( ) {
+
+        // Objects involved
+        var $isDraftCheckbox = $( '#id_is_draft' );
+        var $isRestrictedCheckboxGroup = $( '#id_is_restricted' ).closest( '.form-group' );
+        var $passwordTextInputGroup = $( '#id_password' ).parent( '.form-group' );
+
+        // Initial state
+        if ( $isDraftCheckbox.is( ':checked' ) ) {
+            $isRestrictedCheckboxGroup.hide( );
+            $passwordTextInputGroup.hide( );
+        }
+
+        // Dynamic update
+        $isDraftCheckbox.on( 'change', function( event ) {
+            if ( $( this ).is( ':checked' ) ) {
+                $passwordTextInputGroup.slideUp( );
+                $isRestrictedCheckboxGroup.slideUp( );
+            } else {
+                $isRestrictedCheckboxGroup.slideDown( );
+                $passwordTextInputGroup.slideDown( );
+            }
+        } );
+    };
+
+
+} ( window.POD = window.POD || { }, jQuery ) );

--- a/pod_project/pods/migrations/0004_AlterFields.py
+++ b/pod_project/pods/migrations/0004_AlterFields.py
@@ -43,7 +43,19 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='pod',
             name='is_draft',
-            field=models.BooleanField(default=True, help_text='If you check this box, the video will be visible and accessible only by you.', verbose_name='Draft'),
+            field=models.BooleanField(default=True, help_text='If this box is checked, the video will be visible and accessible only by you.', verbose_name='Draft'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='pod',
+            name='is_restricted',
+            field=models.BooleanField(default=False, help_text='If this box is checked, the video will only be accessible to authenticated users.', verbose_name='Restricted access'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='pod',
+            name='password',
+            field=models.CharField(help_text='The video will be available with the specified password.', max_length=50, null=True, verbose_name='password', blank=True),
             preserve_default=True,
         ),
         migrations.AlterField(

--- a/pod_project/pods/migrations/0004_AlterFields.py
+++ b/pod_project/pods/migrations/0004_AlterFields.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 import filer.fields.file
+import pods.models
 
 
 class Migration(migrations.Migration):
@@ -56,6 +57,12 @@ class Migration(migrations.Migration):
             model_name='pod',
             name='password',
             field=models.CharField(help_text='The video will be available with the specified password.', max_length=50, null=True, verbose_name='password', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='pod',
+            name='tags',
+            field=pods.models.MyTaggableManager(to='taggit.Tag', through='taggit.TaggedItem', blank=True, help_text='Separate tags with spaces, and enclose in quotation marks tags consisting of several words.', verbose_name='Tags'),
             preserve_default=True,
         ),
         migrations.AlterField(

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -291,7 +291,7 @@ class Pod(Video):
 
     tags = MyTaggableManager(
         help_text=_(
-            u'Separate tags with spaces, enclose the tags consist of several words in quotation marks.'),
+            u'Separate tags with spaces, and enclose in quotation marks tags consisting of several words.'),
         verbose_name=_('Tags'), blank=True)
 
     type = models.ForeignKey(Type, verbose_name=_('Type'))

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -305,11 +305,11 @@ class Pod(Video):
     #tags = TaggableManager(help_text=_(u'Séparez les tags par des espaces, mettez les tags constituées de plusieurs mots entre guillemets.'), verbose_name=_('Tags'), blank=True)
 
     is_draft = models.BooleanField(verbose_name=_('Draft'), help_text=_(
-        u'If you check this box, the video will be visible and accessible only by you.'), default=True)
+        u'If this box is checked, the video will be visible and accessible only by you.'), default=True)
     is_restricted = models.BooleanField(verbose_name=_(u'Restricted access'), help_text=_(
-        u'The video is only accessible to authenticated users.'), default=False)
+        u'If this box is checked, the video will only be accessible to authenticated users.'), default=False)
     password = models.CharField(_('password'), help_text=_(
-        u'The video is available with the specified password.'), max_length=50, blank=True, null=True)
+        u'The video will be available with the specified password.'), max_length=50, blank=True, null=True)
 
     class Meta:
         verbose_name = _("Video")
@@ -402,9 +402,9 @@ class Pod(Video):
                 'title': u'%s' %self.title,
                 'owner': u'%s' %self.owner.username,
                 'owner_full_name': u'%s' %self.owner.get_full_name(),
-                "date_added": u'%s' %self.date_added, 
-                "date_evt": u'%s' %self.date_evt if self.date_evt else None, 
-                "description": u'%s' %self.description, 
+                "date_added": u'%s' %self.date_added,
+                "date_evt": u'%s' %self.date_evt if self.date_evt else None,
+                "description": u'%s' %self.description,
                 "thumbnail": u'%s' %self.get_thumbnail_url(),
                 "duration": u'%s' %self.duration,
                 "tags" : list(self.tags.all().values_list('name', flat=True)),
@@ -548,7 +548,7 @@ class ContributorPods(models.Model):
             for element in list_contributorpods:
                 if self.name == element.name and self.role == element.role:
                     msg.append(_("there is already a contributor with the same name and role in the list."))
-                    return msg        
+                    return msg
         return []
 
     def __unicode__(self):
@@ -613,7 +613,7 @@ class TrackPods(models.Model):
             for element in list_trackpods:
                 if self.kind == element.kind and self.lang == element.lang:
                     msg.append(_("there is already a subtitle with the same kind and language in the list."))
-                    return msg        
+                    return msg
         return []
 
 

--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -212,6 +212,38 @@ CKEDITOR.addCss('p{margin-left: auto; margin-right: auto;}');
 </fieldset>
 </form>
 
+<script>
+( function ( ) {
+
+    /*
+        Selecting “Draft” hides “Restricted access” and “Password”
+    */
+
+    // Objects involved
+    var $isDraftCheckbox = $( '#id_is_draft' );
+    var $isRestrictedCheckboxGroup = $( '#id_is_restricted' ).closest( '.form-group' );
+    var $passwordTextInputGroup = $( '#id_password' ).parent( '.form-group' );
+
+    // Initial state
+    if ( $isDraftCheckbox.is( ':checked' ) ) {
+        $isRestrictedCheckboxGroup.hide( );
+        $passwordTextInputGroup.hide( );
+    }
+
+    // Dynamic update
+    $isDraftCheckbox.on( 'change', function( event ) {
+        if ( $( this ).is( ':checked' ) ) {
+            $passwordTextInputGroup.slideUp( );
+            $isRestrictedCheckboxGroup.slideUp( );
+        } else {
+            $isRestrictedCheckboxGroup.slideDown( );
+            $passwordTextInputGroup.slideDown( );
+        }
+    } );
+
+} )( );
+</script>
+
 <!-- DIV PROCESS -->
 <div id="process" class="loader" >
     <div align="center"><div class="anim"></div><!-- <progress value="22" max="100"></progress> --><span>{% trans "Sending, please wait." %}</span></p></div>

--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -213,35 +213,7 @@ CKEDITOR.addCss('p{margin-left: auto; margin-right: auto;}');
 </form>
 
 <script>
-( function ( ) {
-
-    /*
-        Selecting “Draft” hides “Restricted access” and “Password”
-    */
-
-    // Objects involved
-    var $isDraftCheckbox = $( '#id_is_draft' );
-    var $isRestrictedCheckboxGroup = $( '#id_is_restricted' ).closest( '.form-group' );
-    var $passwordTextInputGroup = $( '#id_password' ).parent( '.form-group' );
-
-    // Initial state
-    if ( $isDraftCheckbox.is( ':checked' ) ) {
-        $isRestrictedCheckboxGroup.hide( );
-        $passwordTextInputGroup.hide( );
-    }
-
-    // Dynamic update
-    $isDraftCheckbox.on( 'change', function( event ) {
-        if ( $( this ).is( ':checked' ) ) {
-            $passwordTextInputGroup.slideUp( );
-            $isRestrictedCheckboxGroup.slideUp( );
-        } else {
-            $isRestrictedCheckboxGroup.slideDown( );
-            $passwordTextInputGroup.slideDown( );
-        }
-    } );
-
-} )( );
+POD.setVideoEditForm();
 </script>
 
 <!-- DIV PROCESS -->

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-07-23 17:34+0200\n"
-"PO-Revision-Date: 2015-11-12 17:20+0100\n"
+"PO-Revision-Date: 2015-11-12 17:56+0100\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -1468,10 +1468,10 @@ msgstr "Discipline"
 
 #: pods/models.py:294
 msgid ""
-"Separate tags with spaces, enclose the tags consist of several words in "
-"quotation marks."
+"Separate tags with spaces, and enclose in quotation marks tags consisting of "
+"several words."
 msgstr ""
-"Séparez les mots-clés avec des espaces, placez les mots-clés constitués de "
+"Séparez les mots-clés avec des espaces, et placez ceux constitués de "
 "plusieurs mots entre guillemets."
 
 #: pods/models.py:307

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-07-23 17:34+0200\n"
-"PO-Revision-Date: 2015-11-12 11:22+0100\n"
+"PO-Revision-Date: 2015-11-12 17:20+0100\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -1480,26 +1480,31 @@ msgstr "Brouillon"
 
 #: pods/models.py:308
 msgid ""
-"If you check this box, the video will be visible and accessible only by you."
+"If this box is checked, the video will be visible and accessible only by you."
 msgstr ""
-"Si vous cochez cette case, la vidéo sera visible et accessible uniquement "
-"par vous."
+"Si cette case est cochée, la vidéo sera visible et accessible uniquement par "
+"vous."
 
 #: pods/models.py:309 pods/models.py:994
 msgid "Restricted access"
 msgstr "Accès restreint"
 
 #: pods/models.py:310
-msgid "The video is only accessible to authenticated users."
-msgstr "La vidéo est accessible uniquement aux utilisateurs authentifiés."
+msgid ""
+"If this box is checked, the video will only be accessible to authenticated "
+"users."
+msgstr ""
+"Si cette case est cochée, la vidéo sera accessible uniquement par les "
+"utilisateurs authentifiés."
 
 #: pods/models.py:311
 msgid "password"
 msgstr "Mot de passe"
 
 #: pods/models.py:312
-msgid "The video is available with the specified password."
-msgstr "La vidéo est disponible uniquement avec le mot de passe spécifié."
+msgid "The video will be available with the specified password."
+msgstr ""
+"Le visionnage de la vidéo se fera après avoir spécifié ce mot de passe."
 
 #: pods/models.py:465
 msgid "encodingType"


### PR DESCRIPTION
This is a try to help users better understanding how to manage the visibility of their contents:

*With “Draft” unchecked:*
![capture d ecran 2015-11-12 a 18 01 14](https://cloud.githubusercontent.com/assets/10742818/11124888/77d520ba-8967-11e5-8022-b33ea32ef43b.png)

*With “Draft” checked*
![capture d ecran 2015-11-12 a 18 01 28](https://cloud.githubusercontent.com/assets/10742818/11124893/7a8cb64c-8967-11e5-9c29-edf556c24d3d.png)

We really have problems with that here…
