### PR TITLE
Feature: show latest videos setting

### DIFF
--- a/pod_project/core/templates/flatpages/default.html
+++ b/pod_project/core/templates/flatpages/default.html
@@ -53,12 +53,14 @@ voir http://www.gnu.org/licenses/
     {% block article_content %}
         {{ flatpage.content }}
     {% endblock article_content %}
-    {% block video_list %}
+    {% if SHOW_LATEST_VIDEOS %}
+        {% block video_list %}
         <h3>{% trans 'Here are the latest videos' %}</h3>
         <div id="objects_list_flatpage">
             {% get_last_videos %}
         </div>
-    {% endblock video_list %}
+        {% endblock video_list %}
+    {% endif %}
 {% endblock article %}
 
 

--- a/pod_project/pod_project/settings-sample.py
+++ b/pod_project/pod_project/settings-sample.py
@@ -192,6 +192,8 @@ LOGO_ETB = 'images/lille1_top-01.png'
 LOGO_PLAYER = 'images/logo_white_compact.png'
 SERV_LOGO = 'images/semm.png'
 
+SHOW_LATEST_VIDEOS = True
+
 HELP_MAIL = 'assistance@univ.fr'
 WEBTV = '<a href="http://webtv.univ.fr" id="webtv" class="btn btn-info btn-sm">' \
     'WEBTV<span class="glyphicon glyphicon-link"></span>' \
@@ -250,6 +252,7 @@ TEMPLATE_VISIBLE_SETTINGS = (
     'TEMPLATE_THEME',
     'TITLE_ETB',
     'TITLE_SITE',
+    'SHOW_LATEST_VIDEOS',
     'WEBTV'
 )
 


### PR DESCRIPTION
Sets « SHOW_LATEST_VIDEOS » (True / False) in settings to choose if one wants the latest videos to display in the flatpages that use the « default.html » template.

An alternative could be an new flatpage default template with no « video_list » block at all,  no setting variable, and no test… This new template could be the default one for all other flatpages, and the home page could use the actual one renamed « video_list.html » for instance.