### PR TITLE
Bugfix: non working “back to previous page“ button in video add/edit.

### DIFF
--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -152,12 +152,12 @@ $(document).ready(function() {
     $("#video_form").validate({
         submitHandler: function(form) {
             preventUnloadPrompt = true;
+            form.submit();
             $('html, body').animate({ scrollTop: 0 }, 'slow', function() {
                 $('#video_form').fadeOut('slow', function() {
                     $('#process').fadeIn();
                 });
             });
-            form.submit();
         },
         rules: {
     {% if not form.instance.video %}

--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -291,16 +291,13 @@ var name = "";
 
             {% buttons %}
             <div class="text-center">
-                <button type="submit" class="btn btn-success" name="action1"
-                        value="{% trans "Save" %}">
+                <button type="submit" class="btn btn-success" name="action" value="1">
                     {% bootstrap_icon "save" %} {% trans "Save" %}
                 </button>
-                <button type="submit" class="btn btn-success" name="action2"
-                        value="{% trans "Save and go back to previous page" %}">
+                <button type="submit" class="btn btn-success" name="action" value="2">
                     {% bootstrap_icon "save" %} {% trans "Save and return to the previous page" %}
                 </button>
-                <button type="submit" class="btn btn-success" name="action3"
-                        value="{% trans "Save and watch the video" %}">
+                <button type="submit" class="btn btn-success" name="action" value="3">
                     {% bootstrap_icon "save" %} {% trans "Save and watch the video" %}
                 </button>
             </div>

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -674,9 +674,10 @@ def video_edit(request, slug=None):
             vid.save()
 
             # go back
-            if request.POST.get("action1"):
+            action = request.POST.get("action")
+            if action == "1":
                 return HttpResponseRedirect(reverse('pods.views.video_edit', args=(vid.slug,)))
-            elif request.POST.get("action2"):
+            elif action == "2":
                 return HttpResponseRedirect("%s" % referer)
             else:
                 return HttpResponseRedirect(reverse('pods.views.video', args=(vid.slug,)))


### PR DESCRIPTION
Fixes the problem of the video_edit page referring to itself when form is submitted.
Changes the way the user choice is transmitted (one key with numeric values in $_POST).
Starts uploading before launching visual animations (form disappearing, etc.).
