### PR TITLE
Feature: alert box relies more on bootstrap native behaviors

### DIFF
--- a/pod_project/core/static/JS/navigation.js
+++ b/pod_project/core/static/JS/navigation.js
@@ -251,17 +251,17 @@ $(document).on('click', 'button#button_video_report', function (event) {
 
 
 /*
+
     Creates & shows BS alert boxes w close button
+
 */
 function show_messages( msg, reload, msgClass ) {
 
     var $msgContainer = $( '#show_messages' );
     var msgContent = "";
 
-    if ( typeof msgClass === 'undefined' || ! msgClass ) {
-
-        msgClass = 'danger';
-    }
+    reload = typeof reload !== 'undefined' ? reload : false;
+    msgClass = typeof msgClass !== 'undefined' ? msgClass : 'warning';
 
     msgContent += '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>' + msg;
 
@@ -278,7 +278,6 @@ function show_messages( msg, reload, msgClass ) {
 
         $msgBox.delay( 4000 ).fadeOut( function( ) {
 
-            $msgBox.remove( );
             location.reload( );
         } );
 

--- a/pod_project/core/static/JS/navigation.js
+++ b/pod_project/core/static/JS/navigation.js
@@ -249,25 +249,49 @@ $(document).on('click', 'button#button_video_report', function (event) {
     return false;
 });
 
-function show_messages(msg, reload, msgclass) {
 
-    if(!msgclass||msgclass==='undefined') msgclass='alert-danger';
-    $("#show_messages").attr('class','');
-    $("#show_messages").attr('class','alert '+msgclass+' collapse');
-    if($("#show_messages").length) {
-        if(reload==true) {
-            $("#show_messages").html(msg).fadeIn().delay(4000).fadeOut(function(){location.reload();});
-        } else {
-            if(msgclass=='alert-info')
-                $("#show_messages").html(msg).fadeIn().delay(3000).fadeOut();
-            else
-                $("#show_messages").html(msg).fadeIn();
-        }
+/*
+    Creates & shows BS alert boxes w close button
+*/
+function show_messages( msg, reload, msgClass ) {
+
+    var $msgContainer = $( '#show_messages' );
+    var msgContent = "";
+
+    if ( typeof msgClass === 'undefined' || ! msgClass ) {
+
+        msgClass = 'danger';
     }
+
+    msgContent += '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>' + msg;
+
+    var $msgBox = $( "<div>", {
+        // "fade in" class means the alert box will fade out when the close icon is clicked (!)
+        'class': "alert alert-" + msgClass + " alert-dismissable fade in",
+        'role': "alert",
+        'html': msgContent,
+    } );
+
+    $msgContainer.html( $msgBox );
+
+    if ( reload === true ) {
+
+        $msgBox.delay( 4000 ).fadeOut( function( ) {
+
+            $msgBox.remove( );
+            location.reload( );
+        } );
+
+    } else if ( msgClass === "info" || msgClass === "success" ) {
+
+        $msgBox.delay( 3000 ).fadeOut( function( ) {
+
+            $msgBox.remove( );
+        } );
+    }
+
 }
-$(document).on('click', 'input#close_messages', function() {
-    $("#show_messages").fadeOut();
-});
+
 /** END EVTS PERMANENT **/
 
 

--- a/pod_project/core/templates/base.html
+++ b/pod_project/core/templates/base.html
@@ -265,25 +265,24 @@ voir http://www.gnu.org/licenses/
                             <h3>{% trans 'Report this video' %}</h3>
                         </div>
                         <form method="post" action="{% url 'video_add_report' slug=video.slug %}" id="video_report_form" >
-                        {% csrf_token %}
-                        <div class="modal-body" >
-                            <div class="form-group">
-                            <label for="commentreport">{% trans 'Please, specify the problem:' %}</label><br/>
-                            <textarea rows="5" name="comment" id="commentreport" class="form-control" placeholder="message"></textarea>
+                            {% csrf_token %}
+                            <div class="modal-body" >
+                                <div class="form-group">
+                                    <label for="commentreport">{% trans 'Please, specify the problem:' %}</label><br/>
+                                    <textarea rows="5" name="comment" id="commentreport" class="form-control" placeholder="message"></textarea>
+                                </div>
                             </div>
-                        </div>
-                        <div class="modal-footer">
+                            <div class="modal-footer">
                                 <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Close' %}</button>
                                 <button type="submit" class="btn btn-default" >{% trans 'Send' %}</button>
-                        </div>
+                            </div>
                         </form>
                     </div><!-- /.modal-content -->
                 </div><!-- /.modal-dialog -->
         </div>
         {%endif%}
 
-        <span id="show_messages" class="alert alert-danger collapse" role="alert" >
-            &nbsp;
-        </span>
+        <div id="show_messages"></div>
+
     </body>
 </html>

--- a/pod_project/core/theme/LILLE1/assets/css/pod.css
+++ b/pod_project/core/theme/LILLE1/assets/css/pod.css
@@ -550,6 +550,10 @@ ul li.vjs-menu-title.vjs-disp-menu-title:hover {
 
         Bootstrap mods
 */
+.alert > button.close {
+  font-size: 2.4rem;
+  opacity: .8;
+}
 .nav-pills > li.active > a,
 .nav-pills > li.active > a:hover,
 .nav-pills > li.active > a:focus {

--- a/pod_project/core/theme/LILLE1/less/includes/_pod.less
+++ b/pod_project/core/theme/LILLE1/less/includes/_pod.less
@@ -637,6 +637,11 @@ ul li.vjs-menu-title.vjs-disp-menu-title:hover {
 */
 
 
+.alert > button.close {
+    font-size: 2.4rem;
+    opacity: .8;
+}
+
 .nav-pills > li.active {
 
     & > a,

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -403,7 +403,7 @@ class Pod(Video):
                 'owner': u'%s' %self.owner.username,
                 'owner_full_name': u'%s' %self.owner.get_full_name(),
                 "date_added": u'%s' %self.date_added,
-                "date_evt": u'%s' %self.date_evt.strftime('%Y-%m-%dT%H:%M:%S') if self.date_evt else None, 
+                "date_evt": u'%s' %self.date_evt.strftime('%Y-%m-%dT%H:%M:%S') if self.date_evt else None,
                 "description": u'%s' %self.description,
                 "thumbnail": u'%s' %self.get_thumbnail_url(),
                 "duration": u'%s' %self.duration,
@@ -756,7 +756,7 @@ class EnrichPods(models.Model):
 
         elif (self.type == "document"):
             if(not self.document):
-                msg.append(_('Please enter a correct document.'))
+                msg.append(_('Please select a document.'))
 
         elif (self.type == "embed"):
             if(not self.embed):

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -92,8 +92,8 @@ jQuery(function($) {
     <button type="submit" class="btn btn-success" value="{% trans "Save" %}" name="action1">
         {% bootstrap_icon "save" %} {% trans "Save" %}
     </button>
-    <button type="submit" class="btn btn-success" value="{% trans "Save and back to previous page" %}" name="action2">
-        {% bootstrap_icon "save" %} {% trans "Save and back to previous page" %}
+    <button type="submit" class="btn btn-success" value="{% trans "Save and return to previous page" %}" name="action2">
+        {% bootstrap_icon "save" %} {% trans "Save and return to previous page" %}
     </button>
     <button type="submit" class="btn btn-success" value="{% trans "Save and see channel" %}" name="action3">
         {% bootstrap_icon "save" %} {% trans "Save and see channel" %}
@@ -173,8 +173,8 @@ jQuery(function($) {
     <button type="submit" class="btn btn-success" value="{% trans "Save" %}" name="action1">
         {% bootstrap_icon "save" %} {% trans "Save" %}
     </button>
-    <button type="submit" class="btn btn-success" value="{% trans "Save and back to previous page" %}" name="action2">
-        {% bootstrap_icon "save" %} {% trans "Save and back to previous page" %}
+    <button type="submit" class="btn btn-success" value="{% trans "Save and return to previous page" %}" name="action2">
+        {% bootstrap_icon "save" %} {% trans "Save and return to previous page" %}
     </button>
     <button type="submit" class="btn btn-success" value="{% trans "Save and see channel" %}" name="action3">
         {% bootstrap_icon "save" %} {% trans "Save and see channel" %}

--- a/pod_project/pods/templates/videos/video.html
+++ b/pod_project/pods/templates/videos/video.html
@@ -141,9 +141,6 @@ $(document).on('click', '#button_video_favorite', function (event) {
 {% block mainToolbar %}{% endblock mainToolbar %}
 
 {% block bootstrap3_content %}
-    <!--span id="show_messages" class="alert alert-info collapse" role="alert" >
-            &nbsp;
-    </span-->
     <article id="page-video" class="container{% if request.GET.is_iframe %} embed{% endif %}" role="main" itemprop="video" itemscope itemtype="http://schema.org/VideoObject">
         {% if not request.GET.is_iframe %}
             <ol class="breadcrumb">

--- a/pod_project/pods/templates/videos/video.html
+++ b/pod_project/pods/templates/videos/video.html
@@ -37,18 +37,16 @@ voir http://www.gnu.org/licenses/
             var jqxhr = $.post( $(this).attr("action"), {"comment":comment });
             jqxhr.done(function(data){
                 if(data.msg) {
-                    button='<br/><br/><input type="button" value="{% trans 'Close' %}" id="close_messages" class="btn btn-info btn-sm">';
-                    show_messages(data.msg+button, false, 'alert-info');
+                    show_messages(data.msg, false, 'info');
                     $("#button_video_report").attr('disabled','disabled');
                     $("#mark-as-report").attr('style','color: #ee7d19');
                 } else {
-                    show_messages("{% trans 'You are no longer authenticated. Please log in again.' %} ", true, 'alert-danger');
+                    show_messages("{% trans 'You are no longer authenticated. Please log in again.' %} ", true, 'danger');
                 }
             });
             jqxhr.fail(function($xhr) {
                 var data = $xhr.status+ " : " +$xhr.statusText;
-                button='<br/><br/><input type="button" value="{% trans 'Close' %}" id="close_messages" class="btn btn-info btn-sm">';
-                show_messages("{% trans 'Error sending information.' %} " + "("+data+")<br/>"+"{% trans 'No data could be given.' %}"+button, false, 'alert-danger');
+                show_messages("{% trans 'Error sending information.' %} " + "("+data+")<br/>"+"{% trans 'No data could be given.' %}", false, 'danger');
             });
             $('form#video_report_form').show();
             $('#modal_report_form').modal('hide');
@@ -60,7 +58,7 @@ voir http://www.gnu.org/licenses/
         return false;
     });
 
-$(document).on('click', 'button#button_video_favorite', function (event) {
+$(document).on('click', '#button_video_favorite', function (event) {
     event.preventDefault();
     if($( "#video_favorite_form" ).length==0){
         alert($(this).children('span.sr-only').text());
@@ -72,10 +70,9 @@ $(document).on('click', 'button#button_video_favorite', function (event) {
             $( "#video_favorite_form" ).serialize(),
             function(data) {
                 if(data.msg) {
-                    button='<br/><br/><input type="button" value="{% trans 'Close' %}" id="close_messages" class="btn btn-info btn-sm">';
-                    $("#show_messages").html(data.msg+button, false, 'alert-info').fadeIn();
+                    show_messages(data.msg, false, 'info');
                 } else {
-                    show_messages("{% trans 'You are no longer authenticated. Please log in again.' %} ", true, 'alert-danger');
+                    show_messages("{% trans 'You are no longer authenticated. Please log in again.' %} ", true, 'danger');
                 }
                 if(spanchild.attr('id')=="fav") spanchild.attr('id', 'mark-as-fav');
                 else spanchild.attr('id', 'fav');
@@ -94,8 +91,7 @@ $(document).on('click', 'button#button_video_favorite', function (event) {
             });
         jqxhr.fail(function(data) {
             var data = $xhr.status+ " : " +$xhr.statusText;
-            button='<br/><br/><input type="button" value="{% trans 'Close' %}" id="close_messages" class="btn btn-info btn-sm">';
-            show_messages("{% trans 'Error sending information.' %} " + "("+data+")<br/>"+"{% trans 'No data could be given.' %}"+button, false, 'alert-danger');
+            show_messages("{% trans 'Error sending information.' %} " + "("+data+")<br/>"+"{% trans 'No data could be given.' %}", false, 'danger');
         });
         } else {
             alert(expiredsession);
@@ -145,9 +141,9 @@ $(document).on('click', 'button#button_video_favorite', function (event) {
 {% block mainToolbar %}{% endblock mainToolbar %}
 
 {% block bootstrap3_content %}
-    <span id="show_messages" class="alert alert-info collapse" role="alert" >
+    <!--span id="show_messages" class="alert alert-info collapse" role="alert" >
             &nbsp;
-    </span>
+    </span-->
     <article id="page-video" class="container{% if request.GET.is_iframe %} embed{% endif %}" role="main" itemprop="video" itemscope itemtype="http://schema.org/VideoObject">
         {% if not request.GET.is_iframe %}
             <ol class="breadcrumb">

--- a/pod_project/pods/templates/videos/video_chapter.html
+++ b/pod_project/pods/templates/videos/video_chapter.html
@@ -131,7 +131,6 @@ var preventUnloadPrompt;
 //var messageBeforeUnload = "{% trans "Warning, you will leave this page. If you have made changes without clicking the Save button, your changes will be lost." %}";
 var num = 0;
 var name = '';
-var button='<br/><br/><input type="button" value="{% trans 'Close' %}" id="close_messages" class="btn btn-info btn-sm">';
 /*** For the form ***/;
 var video_duration = {{video.duration}};
 /*** For the Cancel button ***/
@@ -145,10 +144,16 @@ $(document).on("reset", "form", function (e) {
     manageResize();
 
 });
-/*** Function for all buttons expect cancel
-    When the action is modify or new, all button in the first page of chapter are hide and the form is displayed.
-    When the action is delete, a request sent with the chapter id
-    When the action is save, a request sent with the form. Previous, there is two fucntions which verify fields ***/
+
+
+/*** Every button processing expects cancel
+
+    On modify or new action, all buttons in the first page of enrichment
+        are hidden and the form is displayed.
+    On delete action, a request is sent with the enrich id.
+    On save action, a request is sent with the form after a pair of
+        validation functions are runned.
+***/
 
 $(document).on("submit", "#page-video form", function (e) {
     $('form').show();
@@ -176,7 +181,7 @@ $(document).on("submit", "#page-video form", function (e) {
         }
         jqxhr.done(function(data){
             if(data.indexOf("form_chapter")==-1) {
-                show_messages("{% trans 'You are no longer authenticated. Please log in again.' %} ", true, 'alert-danger');
+                show_messages("{% trans 'You are no longer authenticated. Please log in again.' %}", true, 'danger');
             } else {
                 get_form(data);
                 elt.addClass('info');
@@ -185,7 +190,7 @@ $(document).on("submit", "#page-video form", function (e) {
         });
         jqxhr.fail(function($xhr) {
             var data = $xhr.status+ " : " +$xhr.statusText;
-            show_messages("{% trans 'Error getting form.' %} " + "("+data+")"+ "{% trans 'The form could not be recovered.'%} "+button, false, 'alert-danger');
+            show_messages("{% trans 'Error getting form.' %} " + "("+data+")"+ "{% trans 'The form could not be recovered.'%}", false, 'danger');
             $('form.form_modif').show();
             $('form.form_delete').show();
             $('form#form_new').show();
@@ -200,14 +205,14 @@ $(document).on("submit", "#page-video form", function (e) {
             jqxhr = $.post( window.location.href, {"action":"delete", "id": id });
             jqxhr.done(function(data){
                 if(data.list_chapter) {
-                    refrech_list_and_player(data);
+                    refresh_list_and_player(data);
                 } else {
-                    show_messages("{% trans 'You are no longer authenticated. Please log in again.' %} "+button, true, 'alert-danger');
+                    show_messages("{% trans 'You are no longer authenticated. Please log in again.' %}", true, 'danger');
                 }
             });
             jqxhr.fail(function($xhr) {
                 var data = $xhr.status+ " : " +$xhr.statusText;
-                show_messages("{% trans 'Error during deletion.' %} " + "("+data+")<br/>"+"{% trans 'No data could be deleted.' %}"+button, false, 'alert-danger');
+                show_messages("{% trans 'Error during deletion.' %} " + "("+data+")<br/>"+"{% trans 'No data could be deleted.' %}", false, 'danger');
             });
         }
     }else if(action == "save"){
@@ -222,7 +227,7 @@ $(document).on("submit", "#page-video form", function (e) {
             var msg = "";
             msg += overlaptest();
             if(msg != "") {
-                show_messages(msg+button, false, 'alert-danger');
+                show_messages(msg, false, 'danger');
             } else {
                 var data_form = $( "form#form_chapter" ).serializeArray();
                 jqxhr = $.post(
@@ -235,22 +240,22 @@ $(document).on("submit", "#page-video form", function (e) {
                             //alert(data.errors);
                             get_form(data.form);
                         }else{
-                            refrech_list_and_player(data);
+                            refresh_list_and_player(data);
                             $('span#form_chapter').unwrap();
                             $('span#list_chapter').unwrap();
                             manageResize();
                         }
                     } else {
-                        show_messages("{% trans 'You are no longer authenticated. Please log in again.' %} "+button, true, 'alert-danger');
+                        show_messages("{% trans 'You are no longer authenticated. Please log in again.' %}", true, 'danger');
                     }
                 });
                 jqxhr.fail(function($xhr) {
                     var data = $xhr.status+ " : " +$xhr.statusText;
-                    show_messages("{% trans 'Error during recording.' %} " + "("+data+")<br/>"+"{% trans 'No data could be stored.' %}"+button, false, 'alert-danger');
+                    show_messages("{% trans 'Error during recording.' %} " + "("+data+")<br/>"+"{% trans 'No data could be stored.' %}", false, 'danger');
                 });
             }
         }else{
-            show_messages("{% trans 'One or more errors have been found in the form.' %}"+button, false, 'alert-danger');
+            show_messages("{% trans 'One or more errors have been found in the form.' %}", false, 'danger');
         }
 
     }
@@ -258,8 +263,8 @@ $(document).on("submit", "#page-video form", function (e) {
 });
 
 
-/*** refrech the player with modification and show the list of enrich ***/
-function refrech_list_and_player(data){
+/*** Refreshes the player with updates and shows the list of enrichments ***/
+function refresh_list_and_player(data){
     delete videojs.players['player_video']
     $("#form_chapter").html("");
     $('form#form_new').show();

--- a/pod_project/pods/templates/videos/video_completion.html
+++ b/pod_project/pods/templates/videos/video_completion.html
@@ -275,7 +275,7 @@ $(document).on("submit", "#page-video form", function (e) {
             });
             jqxhr.fail(function($xhr) {
                 var data = $xhr.status+ " : " +$xhr.statusText;
-                show_messages("{% trans 'Error deleting. ' %} " + "("+data+")<br/>"+"{% trans 'No data could be deleted.' %}", false, 'danger');
+                show_messages("{% trans 'Error during deletion. ' %} " + "("+data+")<br/>"+"{% trans 'No data could be deleted.' %}", false, 'danger');
             });
         }
     }else if(action == "save"){

--- a/pod_project/pods/templates/videos/video_completion.html
+++ b/pod_project/pods/templates/videos/video_completion.html
@@ -408,7 +408,7 @@ function verify_fields(form){
     }else if(form == "form_download"){
         if($("img#id_document_thumbnail_img").attr('src') == "/static/filer/icons/nofile_48x48.png" ){
             $("img#id_document_thumbnail_img")
-            .before("<span class='form-help-inline'>&nbsp;&nbsp;{% trans 'Please enter a document.' %} </span>")
+            .before("<span class='form-help-inline'>&nbsp;&nbsp;{% trans 'Please select a document.' %} </span>")
             .parents('div.form-group').addClass('has-error');
         }
         $('#table_list_downloads tbody > tr').each(function() {

--- a/pod_project/pods/templates/videos/video_completion.html
+++ b/pod_project/pods/templates/videos/video_completion.html
@@ -6,7 +6,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -36,7 +36,7 @@ voir http://www.gnu.org/licenses/
 /*** table scroll ***/
 table.scroll {
      width: 100%; /* Optional */
-    border-collapse: collapse; 
+    border-collapse: collapse;
     border-spacing: 0;
     /*border: 2px solid black;*/
 }
@@ -70,7 +70,7 @@ table.scroll .btn-sm, table.scroll .btn-group-sm > .btn {
 table.scroll tbody,
 table.scroll thead { display: block }
 
-table.scroll thead tr th { 
+table.scroll thead tr th {
     height: 27px;
     line-height: 27px;
     text-align: left;
@@ -115,14 +115,14 @@ $(window).load(function(){
     manageResize("subtitle");
     manageResize("download");
     $('li.contenuTitre').css('display','none');
-  // On déclare des variables        
+  // On déclare des variables
     var accordion_head = $('#accordeon li a.title');
     var accordion_body = $('#accordeon li.contenuTitre');
 
     //On attribut la classe "active" au premier .titre de la liste et on ouvre par effet de slide .contenuTitre qui suit .active :
     accordion_head.first().addClass('active').parent().next().slideDown('normal');
     accordion_head.first().children().removeClass('glyphicon glyphicon-chevron-down');
-    accordion_head.first().children().addClass('glyphicon glyphicon-chevron-up'); 
+    accordion_head.first().children().addClass('glyphicon glyphicon-chevron-up');
 
     // when click on .titre
     accordion_head.on('click', function(event) {
@@ -135,8 +135,8 @@ $(window).load(function(){
             var name_section = "\"" + text.replace(/\s/g,'') + "\"";
             $(this).attr('title', '{% trans "Hide" %} '+ name_section);
             $(this).children().removeClass('glyphicon glyphicon-chevron-down');
-            $(this).children().addClass('glyphicon glyphicon-chevron-up');  
-            
+            $(this).children().addClass('glyphicon glyphicon-chevron-up');
+
         }else if($(this).attr('class') == 'title active'){
             $(this).parent().next().slideUp('normal');
             $(this).removeClass('active');
@@ -144,7 +144,7 @@ $(window).load(function(){
             var name_section = "\"" + text.replace(/\s/g,'') + "\"";
             $(this).attr('title', '{% trans "Display" %} '+ name_section);
             $(this).children().removeClass('glyphicon glyphicon-chevron-up');
-            $(this).children().addClass('glyphicon glyphicon-chevron-down')           
+            $(this).children().addClass('glyphicon glyphicon-chevron-down')
         }
     });
 });
@@ -176,7 +176,6 @@ var messageBeforeUnload = "";
 var text_to_show = "{% trans "Warning, you will leave this page. If you have made changes without clicking the Save button, your changes will be lost." %}";
 var num = 0;
 var name = '';
-var button='<br/><br/><input type="button" value="{% trans 'Close' %}" id="close_messages" class="btn btn-info btn-sm">';
 
 $(document).on("reset", "#page-video form", function (e) {
     var id_form = $(this).attr("id")
@@ -230,8 +229,8 @@ $(document).on("submit", "#page-video form", function (e) {
             $('span#' + list).wrapAll("<div class = 'col-sm-6' ></div>");
             manageResize(name_form);
         }
-        var elt = $(this).parents('tr'); 
-        $('#'+form).html(ajax_image); 
+        var elt = $(this).parents('tr');
+        $('#'+form).html(ajax_image);
         if (action == "modify"){
             var id = $(this).find('input[name=id]').val();
             jqxhr = $.post( window.location.origin + href, {"action":"modify", "id": id });
@@ -240,15 +239,15 @@ $(document).on("submit", "#page-video form", function (e) {
         }
         jqxhr.done(function(data){
             if(data.indexOf(form)==-1) {
-                show_messages("{% trans 'You are no longer authenticated. Please log in again' %} "+button, true, 'alert-danger');
+                show_messages("{% trans 'You are no longer authenticated. Please log in again' %}", true, 'danger');
             } else {
                 get_form(data, form);
-                elt.addClass('info');      
+                elt.addClass('info');
             }
         });
         jqxhr.fail(function($xhr) {
             var data = $xhr.status+ " : " +$xhr.statusText;
-            show_messages("{% trans 'Error getting form. ' %} " + "("+data+")"+ "{% trans 'the form could not be recovered'%}"+button, false, 'alert-danger');
+            show_messages("{% trans 'Error getting form. ' %} " + "("+data+")"+ "{% trans 'the form could not be recovered'%}", false, 'danger');
             $('form.form_modif').show();
             $('form.form_delete').show();
             $('form.form_new').show();
@@ -257,11 +256,11 @@ $(document).on("submit", "#page-video form", function (e) {
     }else if(action == "delete"){
         var deleteConfirm = "";
         if(name_form == "subtitle"){
-            deleteConfirm = confirm( "{% trans 'Are you sure you want to delete this file ?' %}");
+            deleteConfirm = confirm( "{% trans 'Are you sure you want to delete this file?' %}");
         } else if (name_form == "contributor") {
-            deleteConfirm = confirm( "{% trans 'Are you sure you want to delete this contributor ?' %}");
+            deleteConfirm = confirm( "{% trans 'Are you sure you want to delete this contributor?' %}");
         } else if (name_form == "download") {
-            deleteConfirm = confirm( "{% trans 'Are you sure you want to delete this download ?' %}");
+            deleteConfirm = confirm( "{% trans 'Are you sure you want to delete this download?' %}");
         }
         if (deleteConfirm){
             var id = $(this).find('input[name=id]').val();
@@ -271,12 +270,12 @@ $(document).on("submit", "#page-video form", function (e) {
                     refrech_list(data, form, list);
                     manageResize(name_form);
                 } else {
-                    show_messages("{% trans 'You are no longer authenticated. Please log in again' %} "+button, true, 'alert-danger');
+                    show_messages("{% trans 'You are no longer authenticated. Please log in again' %}", true, 'danger');
                 }
             });
             jqxhr.fail(function($xhr) {
                 var data = $xhr.status+ " : " +$xhr.statusText;
-                show_messages("{% trans 'Error deleting. ' %} " + "("+data+")<br/>"+"{% trans 'No data could be deleted.' %}"+button, false, 'alert-danger');
+                show_messages("{% trans 'Error deleting. ' %} " + "("+data+")<br/>"+"{% trans 'No data could be deleted.' %}", false, 'danger');
             });
         }
     }else if(action == "save"){
@@ -288,14 +287,14 @@ $(document).on("submit", "#page-video form", function (e) {
         msg = verify_fields(form);
         if (!($("span").hasClass("form-help-inline"))){
             if(msg != "")
-                show_messages(msg+button, false, 'alert-danger');
+                show_messages(msg, false, 'danger');
             else {
                 var data_form = $("form#"+form).serializeArray();
                 var href = $("form#" + form).attr("action");
                 jqxhr = $.post(window.location.origin + href,  data_form);
                 jqxhr.done(function(data){
                     if(data.list_data || data.form) {
-                        if(data.errors){  
+                        if(data.errors){
                             //alert(data.errors);
                             get_form(data.form, form);
                         }else{
@@ -303,22 +302,22 @@ $(document).on("submit", "#page-video form", function (e) {
                             if( name_form != "contributor"){
                                 $("span#"+form).unwrap();
                                 $("span#"+list).unwrap();
-                                
+
                             }manageResize(name_form);
                             $(window).scrollTop(100);
-                            show_messages("{% trans 'Changes have been saved.' %}", false, 'alert-info');
+                            show_messages("{% trans 'Changes have been saved.' %}", false, 'info');
                         }
                     } else {
-                       show_messages("{% trans 'You are no longer authenticated. Please log in again' %} "+button, true, 'alert-danger');
+                       show_messages("{% trans 'You are no longer authenticated. Please log in again' %}", true, 'danger');
                     }
                 });
                 jqxhr.fail(function($xhr) {
                     var data = $xhr.status+ " : " +$xhr.statusText;
-                    show_messages("{% trans 'Error recording. ' %} " + "("+data+")<br/>"+"{% trans 'No data could be stored.' %}"+button, false, 'alert-danger');
+                    show_messages("{% trans 'Error recording. ' %} " + "("+data+")<br/>"+"{% trans 'No data could be stored.' %}", false, 'danger');
                 });
             }
         }else{
-            show_messages("{% trans 'Errors found in the form, please correct it.' %}"+button, false, 'alert-danger');
+            show_messages("{% trans 'Errors found in the form, please correct it.' %}", false, 'danger');
         }
     }
 });
@@ -335,7 +334,7 @@ function hide_others_sections(name_form){
             var name_section = "\"" + text.replace(/\s/g,'') + "\"";
             section.title='{% trans "Display '+ name_section + ' section" %}';
             section.firstElementChild.className ="glyphicon glyphicon-chevron-down";
-        }     
+        }
     }
 }
 /*** refrech the list  ***/
@@ -347,7 +346,7 @@ function refrech_list(data, form, list){
     $("span#enrich_player").html(data.player);
     $("span#"+list).html(data.list_data);
 };
-function get_form(data, form) {    
+function get_form(data, form) {
         $("#"+form).hide().html(data).fadeIn();
 
 };
@@ -376,9 +375,9 @@ function verify_fields(form){
             if (id != $(this).find('input[name=id]')[0].value  && $(this).find('td[class=contributor_name]')[0].innerHTML == new_name && $(this).find('td[class=contributor_role]')[0].innerHTML == new_role){
                var text = "{% trans 'There is already a contributor with this same name and role in the list.' %}.";
                msg+="<br/>"+ text ;
-               return msg;  
+               return msg;
             }
-        });      
+        });
     }else if(form == "form_subtitle"){
         if(document.getElementById("id_kind").value == "" || (document.getElementById("id_kind").value !="subtitles" && document.getElementById("id_kind").value !="captions")){
             $("input#id_kind")
@@ -437,28 +436,28 @@ function verify_fields(form){
 <article id="page-video" class="container" role="main" itemprop="video" itemscope itemtype="http://schema.org/VideoObject">
     <ol class="breadcrumb">
         {% block breadcrumbs %}
-        {{ block.super }} 
+        {{ block.super }}
         <li><a href="{% url 'owner_videos_list' %}">{% trans "My videos" %}</a></li>
         <li class="active"> {% trans "Completion video" %} "{{video.title}}"</li>
         {% endblock breadcrumbs %}
     </ol>
         <br/>
         <div class="row" id="info_video">
-            <div id="accordeon" class="col-sm-9"> 
+            <div id="accordeon" class="col-sm-9">
                 <!-- Le lien qui sert de bouton pour ouvrir le dropdown -->
                 <li><a id = "section_contributor" href="#"  title="{% trans "Display &quot;Contributor(s)&quot; section" %}" class = "title" >{% trans "Contributor(s)" %}&nbsp; <span class="glyphicon glyphicon-chevron-down" /> </a></li>
                 <li class="contenuTitre">
                     &nbsp;
                     <span id="list_contributor">
-                        <!-- place for form, it will be replace by a form : empty or to modify -->   
+                        <!-- place for form, it will be replace by a form : empty or to modify -->
                         {%include 'videos/completion/contributor/list_contributor.html'%}
-                    </span> 
+                    </span>
                     <span id= "form_contributor">
                     {% if form_contributor %}
                         {%include 'videos/completion/contributor/form_contributor.html' with form_contributor=form_contributor%}
                     {%endif%}
                     <!-- This button will add a new form when clicked -->
-                    </span>        
+                    </span>
                     <form  class = "form_new" id="form_new_contributor" action="{% url 'video_completion_contributor' slug=video.slug  %}" method="post">
                         {% csrf_token %}
                         <input type="hidden" name="action" value="new">
@@ -478,9 +477,9 @@ function verify_fields(form){
                     </span>
                     &nbsp;
                     <span id="list_subtitle">
-                        <!-- place for form, it will be replace by a form : empty or to modify -->   
+                        <!-- place for form, it will be replace by a form : empty or to modify -->
                         {%include 'videos/completion/subtitle/list_subtitle.html'%}
-                    </span>    
+                    </span>
                     <form  class = "form_new" id="form_new_subtitle" action="{% url 'video_completion_subtitle' slug=video.slug  %}" method="post">
                         {% csrf_token %}
                         <input type="hidden" name="action" value="new">
@@ -489,17 +488,17 @@ function verify_fields(form){
                 </li>
                 &nbsp;
                 <li><a id = "section_download" href="#" title="{% trans "Display &quot; Additional resource(s)&quot; section" %}" class="title" >{% trans "Additional resource(s)" %}&nbsp; <span class="glyphicon glyphicon-chevron-down" /></a></li>
-                <li class="contenuTitre">  
+                <li class="contenuTitre">
                     <span id= "form_download">
                     {% if form_download %}
                         {%include 'videos/completion/download/form_download.html' with form_download=form_download %}
                     {%endif%}
                     </span>
                     &nbsp;
-                    <span id="list_download">              
-                        <!-- place for form, it will be replace by a form : empty or to modify -->   
-                        {%include 'videos/completion/download/list_download.html'%}    
-                    </span>         
+                    <span id="list_download">
+                        <!-- place for form, it will be replace by a form : empty or to modify -->
+                        {%include 'videos/completion/download/list_download.html'%}
+                    </span>
                     <form  class = "form_new"  id="form_new_download" action="{% url 'video_completion_download' slug=video.slug  %}" method="post">
                         {% csrf_token %}
                         <input type="hidden" name="action" value="new">
@@ -520,7 +519,7 @@ function verify_fields(form){
                         <h4>
                             <span class="glyphicon glyphicon-info-sign"></span> {% trans 'Information' %}
                         </h4>
-                        {% if request.user.is_staff %}    
+                        {% if request.user.is_staff %}
                             <p>{% trans 'Several web sites allows you to subtitle or caption videos (for example: Amara).' %}</p>
                             <p>{% trans 'You can add several subtitle or caption files to a single video (for example, in order to subtitle or caption this video in several languages).' %} </p>
                             <p>{% trans 'For this purpose, you will need the URL of your video. This URL is a direct access to this video. Please do not communicate it outside of this site in order to avoid any misuse.' %}</p>
@@ -533,7 +532,7 @@ function verify_fields(form){
                         {% endif %}
                     </div>
                 </aside>
-        </div>        
+        </div>
     </article>
 {% endblock bootstrap3_content %}
 {% block box %}{% endblock box %}

--- a/pod_project/pods/templates/videos/video_completion.html
+++ b/pod_project/pods/templates/videos/video_completion.html
@@ -267,7 +267,7 @@ $(document).on("submit", "#page-video form", function (e) {
             jqxhr = $.post( window.location.origin + href, {"action":"delete", "id": id });
             jqxhr.done(function(data){
                 if(data.list_data) {
-                    refrech_list(data, form, list);
+                    refresh_list(data, form, list);
                     manageResize(name_form);
                 } else {
                     show_messages("{% trans 'You are no longer authenticated. Please log in again' %}", true, 'danger');
@@ -298,7 +298,7 @@ $(document).on("submit", "#page-video form", function (e) {
                             //alert(data.errors);
                             get_form(data.form, form);
                         }else{
-                            refrech_list(data, form, list);
+                            refresh_list(data, form, list);
                             if( name_form != "contributor"){
                                 $("span#"+form).unwrap();
                                 $("span#"+list).unwrap();
@@ -337,8 +337,8 @@ function hide_others_sections(name_form){
         }
     }
 }
-/*** refrech the list  ***/
-function refrech_list(data, form, list){
+/*** refreshes the list  ***/
+function refresh_list(data, form, list){
     $("#"+form).html("");
     $('form.form_new').show();
     $('form').show()

--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -295,7 +295,7 @@ var name = "";
                     {% bootstrap_icon "save" %} {% trans "Save" %}
                 </button>
                 <button type="submit" class="btn btn-success" name="action" value="2">
-                    {% bootstrap_icon "save" %} {% trans "Save and return to the previous page" %}
+                    {% bootstrap_icon "save" %} {% trans "Save and return to previous page" %}
                 </button>
                 <button type="submit" class="btn btn-success" name="action" value="3">
                     {% bootstrap_icon "save" %} {% trans "Save and watch the video" %}

--- a/pod_project/pods/templates/videos/video_enrich.html
+++ b/pod_project/pods/templates/videos/video_enrich.html
@@ -226,7 +226,7 @@ $(document).on("submit", "#page-video form", function (e) {
             msg += verify_end_start_items();
             msg += overlaptest();
             if(msg != "") {
-                show_messages(msg+button, false, 'danger');
+                show_messages(msg, false, 'danger');
             } else {
                 var data_form = $( "form#form_enrich" ).serializeArray();
                 jqxhr = $.post(

--- a/pod_project/pods/templates/videos/video_enrich.html
+++ b/pod_project/pods/templates/videos/video_enrich.html
@@ -204,7 +204,7 @@ $(document).on("submit", "#page-video form", function (e) {
             jqxhr = $.post( window.location.href, {"action":"delete", "id": id });
             jqxhr.done(function(data){
                 if(data.list_enrich) {
-                    refrech_list_and_player(data);
+                    refresh_list_and_player(data);
                 } else {
                     show_messages("{% trans 'You are no longer authenticated. Please log in again.' %}", true, 'danger');
                 }
@@ -239,7 +239,7 @@ $(document).on("submit", "#page-video form", function (e) {
                             //alert(data.errors);
                             get_form(data.form);
                         }else{
-                            refrech_list_and_player(data);
+                            refresh_list_and_player(data);
                             $(window).scrollTop(360);
                             show_messages("{% trans 'Changes have been saved.' %}", false, 'info');
                         }
@@ -263,8 +263,8 @@ $(document).on("submit", "#page-video form", function (e) {
 $(document).on('change', '#page-video select#id_type', function() {
     enrich_type();
 });
-/*** refrech the player with modification and show the list of enrich ***/
-function refrech_list_and_player(data){
+/*** refreshes the player with modification and show the list of enrich ***/
+function refresh_list_and_player(data){
     delete videojs.players['player_video']
     $("#form_enrich").html("");
     $('form#form_new').show();

--- a/pod_project/pods/templates/videos/video_enrich.html
+++ b/pod_project/pods/templates/videos/video_enrich.html
@@ -138,7 +138,6 @@ var preventUnloadPrompt;
 //var messageBeforeUnload = "{% trans "Warning, you will leave this page. If you have made changes without clicking the Save button, your changes will be lost." %}";
 var num = 0;
 var name = '';
-var button='<br/><br/><input type="button" value="{% trans 'Close' %}" id="close_messages" class="btn btn-info btn-sm">';
 /*** For the form ***/;
 var video_duration = {{video.duration}};
 
@@ -151,10 +150,14 @@ $(document).on("reset", "#page-video form", function (e) {
     manageResize();
 });
 
-/*** Function for all buttons expect cancel
-    When the action is modify or new, all button in the first page of enrich are hide and the form is displayed.
-    When the action is delete, a request sent with the enrich id
-    When the action is save, a request sent with the form. Previous, there is two fucntions which verify fields ***/
+/*** Every button processing expects cancel
+
+    On modify or new action, all buttons in the first page of enrichment
+        are hidden and the form is displayed.
+    On delete action, a request is sent with the enrich id.
+    On save action, a request is sent with the form after a pair of
+        validation functions are runned.
+***/
 
 $(document).on("submit", "#page-video form", function (e) {
     $('form').show();
@@ -177,7 +180,7 @@ $(document).on("submit", "#page-video form", function (e) {
         }
         jqxhr.done(function(data){
             if(data.indexOf("form_enrich")==-1) {
-                show_messages("{% trans 'You are no longer authenticated. Please log in again.' %} "+button, true, 'alert-danger');
+                show_messages("{% trans 'You are no longer authenticated. Please log in again.' %}", true, 'danger');
             } else {
                 get_form(data);
                 elt.addClass('info');
@@ -186,7 +189,7 @@ $(document).on("submit", "#page-video form", function (e) {
         });
         jqxhr.fail(function($xhr) {
             var data = $xhr.status+ " : " +$xhr.statusText;
-            show_messages("{% trans 'Error getting form.' %} " + "("+data+")"+ "{% trans 'The form could not be recovered.'%} "+button, false, 'alert-danger');
+            show_messages("{% trans 'Error getting form.' %} " + "("+data+")"+ "{% trans 'The form could not be recovered.'%}", false, 'danger');
             $('form.form_modif').show();
             $('form.form_delete').show();
             $('form#form_new').show();
@@ -203,12 +206,12 @@ $(document).on("submit", "#page-video form", function (e) {
                 if(data.list_enrich) {
                     refrech_list_and_player(data);
                 } else {
-                    show_messages("{% trans 'You are no longer authenticated. Please log in again.' %} "+button, true, 'alert-danger');
+                    show_messages("{% trans 'You are no longer authenticated. Please log in again.' %}", true, 'danger');
                 }
             });
             jqxhr.fail(function($xhr) {
                 var data = $xhr.status+ " : " +$xhr.statusText;
-                show_messages("{% trans 'Error during deletion.' %} " + "("+data+")<br/>"+"{% trans 'No data could be deleted.' %}"+button, false, 'alert-danger');
+                show_messages("{% trans 'Error during deletion.' %} " + "("+data+")<br/>"+"{% trans 'No data could be deleted.' %}", false, 'danger');
             });
         }
     }else if(action == "save"){
@@ -223,7 +226,7 @@ $(document).on("submit", "#page-video form", function (e) {
             msg += verify_end_start_items();
             msg += overlaptest();
             if(msg != "") {
-                show_messages(msg+button, false, 'alert-danger');
+                show_messages(msg+button, false, 'danger');
             } else {
                 var data_form = $( "form#form_enrich" ).serializeArray();
                 jqxhr = $.post(
@@ -238,19 +241,19 @@ $(document).on("submit", "#page-video form", function (e) {
                         }else{
                             refrech_list_and_player(data);
                             $(window).scrollTop(360);
-                            show_messages("{% trans 'Changes have been saved.' %}", false, 'alert-info');
+                            show_messages("{% trans 'Changes have been saved.' %}", false, 'info');
                         }
                     } else {
-                        show_messages("{% trans 'You are no longer authenticated. Please log in again.' %} "+button, true, 'alert-danger');
+                        show_messages("{% trans 'You are no longer authenticated. Please log in again.' %}", true, 'danger');
                     }
                 });
                 jqxhr.fail(function($xhr) {
                     var data = $xhr.status+ " : " +$xhr.statusText;
-                    show_messages("{% trans 'Error during recording.' %} " + "("+data+")<br/>"+"{% trans 'No data could be stored.' %}"+button, false, 'alert-danger');
+                    show_messages("{% trans 'Error during recording.' %} " + "("+data+")<br/>"+"{% trans 'No data could be stored.' %}", false, 'danger');
                 });
             }
         }else{
-            show_messages("{% trans 'One or more errors have been found in the form.' %}"+button, false, 'alert-danger');
+            show_messages("{% trans 'One or more errors have been found in the form.' %}", false, 'danger');
         }
     }
 

--- a/pod_project/pods/templates/videos/video_enrich.html
+++ b/pod_project/pods/templates/videos/video_enrich.html
@@ -370,7 +370,7 @@ function verify_fields(){
         case "document":
             if($("#id_document_thumbnail_img").attr('src') == "/static/filer/icons/nofile_48x48.png"){ //check with id_document value
                 $("img#id_document_thumbnail_img")
-                    .before("<span class='form-help-inline'>&nbsp; &nbsp;{% trans 'Please enter a correct document.' %} </span>")
+                    .before("<span class='form-help-inline'>&nbsp; &nbsp;{% trans 'Please select a document.' %} </span>")
                     .parents('div.form-group').addClass('has-error');
             }
             break;

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -511,7 +511,7 @@ def video_add_favorite(request, slug):
             favorite.delete()
             msg = _(u'The video has been removed from your favorites.')
         if request.is_ajax():
-            some_data_to_dump = {'msg': "%s." % msg}
+            some_data_to_dump = {'msg': "%s" % msg}
             data = json.dumps(some_data_to_dump)
             return HttpResponse(data, content_type='application/json')
         messages.add_message(request, messages.INFO, msg)

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-03-30 11:56+0200\n"
-"PO-Revision-Date: 2016-03-30 11:58+0200\n"
+"PO-Revision-Date: 2016-03-30 12:23+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 1.8.6\n"
+"X-Generator: Poedit 1.8.7\n"
 
 #: core/forms.py:63
 msgid "Please indicate the result of the following operation hereunder"
@@ -1729,7 +1729,7 @@ msgstr "Documents"
 
 #: pods/models.py:652
 msgid "please enter a document "
-msgstr "Veuillez renseigner un document. "
+msgstr "veuillez sélectionner un document "
 
 #: pods/models.py:667
 msgid "this document is already contained in the list."
@@ -1832,8 +1832,9 @@ msgid "Please enter a correct weblink."
 msgstr "Veuillez renseigner un lien internet."
 
 #: pods/models.py:759 pods/templates/videos/video_enrich.html:373
-msgid "Please enter a correct document."
-msgstr "Veuillez renseigner un document."
+#: pods/templates/videos/video_completion.html:411
+msgid "Please select a document."
+msgstr "Veuillez sélectionner un document."
 
 #: pods/models.py:763 pods/templates/videos/video_enrich.html:380
 msgid "Please enter a correct embed."
@@ -1845,16 +1846,16 @@ msgstr "Veuillez choisir un type d'enrichissement."
 
 #: pods/models.py:778
 msgid "The value of the start field is greater than the value of end field."
-msgstr "La valeur du commencement ne peut être supérieur à celle de la fin."
+msgstr "La valeur du commencement ne peut être supérieure à celle de la fin."
 
 #: pods/models.py:781
 msgid "The value of end field is greater than the video duration."
 msgstr ""
-"La valeur de fin d'enrichissement est supérieur à la durée de la vidéo."
+"La valeur de fin d'enrichissement est supérieure à la durée de la vidéo."
 
 #: pods/models.py:783
 msgid "End field and start field can't be equal."
-msgstr "Le commencement et la fin ne peuvent être équivalent."
+msgstr "Le commencement et la fin ne peuvent être équivalents."
 
 #: pods/models.py:801 pods/templates/videos/video_enrich.html:422
 msgid "There is an overlap with the enrichment "
@@ -2025,7 +2026,8 @@ msgstr "Édition de la chaîne"
 #: pods/templates/channels/channel_edit.html:96
 #: pods/templates/channels/channel_edit.html:176
 #: pods/templates/channels/channel_edit.html:177
-msgid "Save and back to previous page"
+#: pods/templates/videos/video_edit.html:298
+msgid "Save and return to previous page"
 msgstr "Enregistrer et revenir à la page précédente"
 
 #: pods/templates/channels/channel_edit.html:98
@@ -2661,10 +2663,6 @@ msgid ""
 "There is already a subtitle with this same kind and language in the list."
 msgstr "il y a déjà un fichier de même type et de même langue"
 
-#: pods/templates/videos/video_completion.html:411
-msgid "Please enter a document."
-msgstr "Veuillez renseigner un document."
-
 #: pods/templates/videos/video_completion.html:418
 msgid ""
 "There is already a download with this same name of document in the list."
@@ -2814,10 +2812,6 @@ msgstr ""
 #: pods/templates/videos/video_edit.html:283
 msgid "Please come back tomorrow!"
 msgstr "Merci de revenir demain !"
-
-#: pods/templates/videos/video_edit.html:298
-msgid "Save and return to the previous page"
-msgstr "Enregistrer et revenir à la page précédente"
 
 #: pods/templates/videos/video_edit.html:301
 msgid "Save and watch the video"
@@ -3214,6 +3208,3 @@ msgstr ""
 #: pods/views.py:1693
 msgid "New mediacourse added."
 msgstr "Nouveaux médiacours ajoutés."
-
-#~ msgid "Save and go back to previous page"
-#~ msgstr "Enregistrer et revenir à la page précédente"

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-03-30 11:56+0200\n"
-"PO-Revision-Date: 2016-03-30 12:23+0200\n"
+"PO-Revision-Date: 2016-03-30 16:13+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -2491,6 +2491,7 @@ msgid "Are you sure you want to delete this chapter?"
 msgstr "Etes-vous sûr de vouloir supprimer ce chapitre ?"
 
 #: pods/templates/videos/video_chapter.html:215
+#: pods/templates/videos/video_completion.html:278
 #: pods/templates/videos/video_enrich.html:214
 msgid "Error during deletion."
 msgstr "Erreur lors de la suppression."
@@ -2606,10 +2607,6 @@ msgstr "Etes-vous sûr de vouloir supprimer ce contributeur ?"
 #: pods/templates/videos/video_completion.html:263
 msgid "Are you sure you want to delete this download?"
 msgstr "Etes-vous sûr de vouloir supprimer ce document à télécharger ?"
-
-#: pods/templates/videos/video_completion.html:278
-msgid "Error deleting. "
-msgstr "Erreur lors de la suppression."
 
 #: pods/templates/videos/video_completion.html:308
 #: pods/templates/videos/video_enrich.html:244

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-01 16:52+0100\n"
-"PO-Revision-Date: 2016-01-14 18:09+0100\n"
+"POT-Creation-Date: 2016-03-30 11:56+0200\n"
+"PO-Revision-Date: 2016-03-30 11:58+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -108,8 +108,7 @@ msgstr ""
 "étiquette formée uniquement de lettres (non accentuées), de chiffres, de "
 "l'underscore (barre de soulignement) et du tiret."
 
-#: core/models.py:157
-#: core/templates/admin/filer/folder/directory_table.html:30
+#: core/models.py:157 core/templates/admin/filer/folder/directory_table.html:30
 #: core/templates/admin/filer/folder/directory_table.html:70 pods/models.py:73
 #: pods/templates/search/search_video.html:163
 msgid "Owner"
@@ -151,7 +150,7 @@ msgstr "Vignette"
 msgid "Overview"
 msgstr "Vue d'ensemble"
 
-#: core/models.py:189 core/models.py:222 pods/templates/videos/video.html:329
+#: core/models.py:189 core/models.py:222 pods/templates/videos/video.html:322
 msgid "Duration"
 msgstr "Durée"
 
@@ -188,8 +187,7 @@ msgstr "réglage d'encodage"
 msgid "encoding types"
 msgstr "réglages d'encodage"
 
-#: core/models.py:267
-#: core/templates/admin/filer/folder/directory_table.html:13
+#: core/models.py:267 core/templates/admin/filer/folder/directory_table.html:13
 msgid "Name"
 msgstr "Nom"
 
@@ -229,8 +227,7 @@ msgstr "Vous n'êtes pas autorisé à accéder à cette ressource"
 #: core/templates/403.html:51 core/templates/404.html:51
 #: core/templates/admin/base.html:47 core/templates/base.html:97
 #: core/templates/contactus/contactus.html:43 core/templates/navbar.html:41
-#: core/templates/registration/login.html:99
-#: core/templates/userProfile.html:82
+#: core/templates/registration/login.html:99 core/templates/userProfile.html:82
 msgid "Home"
 msgstr "Accueil"
 
@@ -414,8 +411,8 @@ msgstr "Visualiser sur le site"
 
 #: core/templates/admin/filer/image/change_form.html:18
 #: core/templates/contactus/contactus.html:41
-#: core/templates/registration/login.html:97
-#: core/templates/userProfile.html:80 core/templates/userProfile.html.py:86
+#: core/templates/registration/login.html:97 core/templates/userProfile.html:80
+#: core/templates/userProfile.html.py:86
 msgid "Back"
 msgstr "Retour"
 
@@ -426,7 +423,7 @@ msgstr "Aperçu en taille maximale"
 #: core/templates/admin/filer/widgets/admin_file.html:10
 #: core/templates/admin/filer/widgets/admin_file.html:11
 #: core/templates/admin/filer/widgets/admin_file.html:13
-#: pods/templates/videos/video.html:322 pods/templates/videos/videos.html:67
+#: pods/templates/videos/video.html:315 pods/templates/videos/videos.html:67
 msgid "File missing"
 msgstr "Fichier manquant"
 
@@ -487,10 +484,10 @@ msgid "See all"
 msgstr "Afficher tout"
 
 #: core/templates/base.html:178 pods/models.py:295
-#: pods/templates/search/search_video.html:187
-#: pods/templates/tags/tags.html:25 pods/templates/tags/tags.html.py:86
-#: pods/templates/tags/tags.html:96 pods/templates/tags/tags.html.py:104
-#: pods/templates/videos/video.html:303 pods/templates/videos/videos.html:130
+#: pods/templates/search/search_video.html:187 pods/templates/tags/tags.html:25
+#: pods/templates/tags/tags.html.py:86 pods/templates/tags/tags.html:96
+#: pods/templates/tags/tags.html.py:104 pods/templates/videos/video.html:296
+#: pods/templates/videos/videos.html:130
 msgid "Tags"
 msgstr "Mots clés"
 
@@ -509,9 +506,8 @@ msgstr "Notes"
 #: pods/templates/pagination.html:41
 #: pods/templates/videos/chapter/form_chapter.html:43
 #: pods/templates/videos/enrich/form_enrich.html:43
-#: pods/templates/videos/video.html:491 pods/templates/videos/video.html:492
+#: pods/templates/videos/video.html:484 pods/templates/videos/video.html:485
 #: pods/templates/videos/video_edit.html:295
-#: pods/templates/videos/video_edit.html:296
 msgid "Save"
 msgstr "Enregistrer"
 
@@ -519,10 +515,10 @@ msgstr "Enregistrer"
 #: core/templates/userProfile.html:103
 #: pods/templates/channels/my_channels.html:72
 #: pods/templates/videos/my_videos.html:64
-#: pods/templates/videos/video_chapter.html:375
-#: pods/templates/videos/video_completion.html:521
-#: pods/templates/videos/video_edit.html:341
-#: pods/templates/videos/video_enrich.html:480
+#: pods/templates/videos/video_chapter.html:380
+#: pods/templates/videos/video_completion.html:520
+#: pods/templates/videos/video_edit.html:338
+#: pods/templates/videos/video_enrich.html:483
 msgid "Information"
 msgstr "Information"
 
@@ -553,11 +549,6 @@ msgstr ""
 "la vidéo d'aide pour l'utilisation du gestionnaire de fichier."
 
 #: core/templates/base.html:252 core/templates/base.html.py:276
-#: pods/templates/videos/video.html:40 pods/templates/videos/video.html:50
-#: pods/templates/videos/video.html:75 pods/templates/videos/video.html:97
-#: pods/templates/videos/video_chapter.html:134
-#: pods/templates/videos/video_completion.html:179
-#: pods/templates/videos/video_enrich.html:141
 msgid "Close"
 msgstr "Fermer"
 
@@ -572,8 +563,8 @@ msgstr "Veuillez expliquer le problème :"
 #: core/templates/base.html:277 core/templates/contactus/contactus.html:35
 #: core/templates/header.html:50 core/templates/userProfile.html:74
 #: pods/templates/mediacourses/mediacourses_add.html:66
-#: pods/templates/videos/video.html:185 pods/templates/videos/video.html:186
-#: pods/templates/videos/video.html:223 pods/templates/videos/video.html:241
+#: pods/templates/videos/video.html:178 pods/templates/videos/video.html:179
+#: pods/templates/videos/video.html:216 pods/templates/videos/video.html:234
 msgid "Send"
 msgstr "Envoyer"
 
@@ -581,10 +572,10 @@ msgstr "Envoyer"
 #: core/templates/userProfile.html:65 core/views.py:166
 #: pods/templates/channels/channel_edit.html:78
 #: pods/templates/mediacourses/mediacourses_add.html:53
-#: pods/templates/videos/video_chapter.html:253
+#: pods/templates/videos/video_chapter.html:258
 #: pods/templates/videos/video_edit.html:264
-#: pods/templates/videos/video_enrich.html:253 pods/views.py:188
-#: pods/views.py:453 pods/views.py:679 pods/views.py:1620
+#: pods/templates/videos/video_enrich.html:256 pods/views.py:191
+#: pods/views.py:456 pods/views.py:686 pods/views.py:1627
 msgid "One or more errors have been found in the form."
 msgstr "Une ou plusieurs erreurs ont été trouvées dans le formulaire."
 
@@ -633,14 +624,13 @@ msgid "Log in"
 msgstr "Connexion"
 
 #: core/templates/navbar.html:45 core/templates/navbar.html.py:67
-#: pods/models.py:85 pods/models.py:301
-#: pods/templates/channels/channel.html:49
+#: pods/models.py:85 pods/models.py:301 pods/templates/channels/channel.html:49
 #: pods/templates/channels/channels.html:24
 #: pods/templates/channels/channels.html:31
 #: pods/templates/channels/channels.html:39
 #: pods/templates/channels/channels.html:41
 #: pods/templates/channels/my_channels.html:52
-#: pods/templates/videos/video.html:157
+#: pods/templates/videos/video.html:150
 msgid "Channels"
 msgstr "Chaînes"
 
@@ -657,7 +647,7 @@ msgid "Types"
 msgstr "Types"
 
 #: core/templates/navbar.html:115 pods/models.py:316
-#: pods/templates/videos/video.html:160 pods/templates/videos/videos.html:26
+#: pods/templates/videos/video.html:153 pods/templates/videos/videos.html:26
 #: pods/templates/videos/videos.html:30 pods/templates/videos/videos.html:32
 msgid "Videos"
 msgstr "Vidéos"
@@ -703,7 +693,7 @@ msgstr "N'hésitez pas à nous contacter pour toute assistance :"
 #: core/templates/registration/login.html:119
 #: core/theme/LILLE1/templates/footer.html:27
 #: core/theme/LILLE1/templates/footer.html:28 core/views.py:223
-#: pods/templates/videos/video.html:191
+#: pods/templates/videos/video.html:184
 msgid "Contact us"
 msgstr "Contactez nous"
 
@@ -755,7 +745,7 @@ msgid "Login"
 msgstr "Identifiant"
 
 #: core/views.py:95 pods/admin.py:98 pods/forms.py:288
-#: pods/templates/videos/video_edit.html:385
+#: pods/templates/videos/video_edit.html:382
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -1524,7 +1514,7 @@ msgstr "Thèmes"
 #: pods/models.py:167 pods/models.py:297 pods/models.py:701
 #: pods/templates/search/search_video.html:175
 #: pods/templates/videos/enrich/list_enrich.html:33
-#: pods/templates/videos/video.html:335
+#: pods/templates/videos/video.html:328
 msgid "Type"
 msgstr "Type"
 
@@ -1537,7 +1527,7 @@ msgid "slug"
 msgstr "titre court"
 
 #: pods/models.py:201 pods/templates/search/search_video.html:199
-#: pods/templates/videos/video.html:342
+#: pods/templates/videos/video.html:335
 msgid "Discipline"
 msgstr "Discipline"
 
@@ -1549,7 +1539,7 @@ msgstr ""
 "Séparez les mots-clés avec des espaces, placez les mots-clés constitués de "
 "plusieurs mots entre guillemets."
 
-#: pods/models.py:307 pods/templates/videos/video_edit.html:367
+#: pods/models.py:307 pods/templates/videos/video_edit.html:364
 msgid "Draft"
 msgstr "Brouillon"
 
@@ -1561,7 +1551,7 @@ msgstr ""
 "vous."
 
 #: pods/models.py:309 pods/models.py:999
-#: pods/templates/videos/video_edit.html:375
+#: pods/templates/videos/video_edit.html:372
 msgid "Restricted access"
 msgstr "Accès restreint"
 
@@ -1810,8 +1800,8 @@ msgid "Enrichments"
 msgstr "Enrichissements"
 
 #: pods/models.py:736 pods/models.py:859
-#: pods/templates/videos/video_chapter.html:276
-#: pods/templates/videos/video_enrich.html:325
+#: pods/templates/videos/video_chapter.html:281
+#: pods/templates/videos/video_enrich.html:328
 msgid "Please enter a title from 2 to 100 characters."
 msgstr "Veuillez renseigner un titre contenant entre 2 et 100 caractères."
 
@@ -1829,27 +1819,27 @@ msgstr ""
 "Veuillez renseigner une valeur de fin d'enrichissement comprise entre 1 et "
 "%(duration)s."
 
-#: pods/models.py:747 pods/templates/videos/video_enrich.html:343
+#: pods/models.py:747 pods/templates/videos/video_enrich.html:346
 msgid "Please enter a correct image."
 msgstr "Veuillez renseigner une image."
 
-#: pods/models.py:751 pods/templates/videos/video_enrich.html:350
+#: pods/models.py:751 pods/templates/videos/video_enrich.html:353
 msgid "Please enter a correct richtext."
 msgstr "Veuillez renseigner un texte."
 
-#: pods/models.py:755 pods/templates/videos/video_enrich.html:357
+#: pods/models.py:755 pods/templates/videos/video_enrich.html:360
 msgid "Please enter a correct weblink."
 msgstr "Veuillez renseigner un lien internet."
 
-#: pods/models.py:759 pods/templates/videos/video_enrich.html:370
+#: pods/models.py:759 pods/templates/videos/video_enrich.html:373
 msgid "Please enter a correct document."
 msgstr "Veuillez renseigner un document."
 
-#: pods/models.py:763 pods/templates/videos/video_enrich.html:377
+#: pods/models.py:763 pods/templates/videos/video_enrich.html:380
 msgid "Please enter a correct embed."
 msgstr "Veuillez renseigner un code embed."
 
-#: pods/models.py:765 pods/templates/videos/video_enrich.html:389
+#: pods/models.py:765 pods/templates/videos/video_enrich.html:392
 msgid "Please enter a type in index field."
 msgstr "Veuillez choisir un type d'enrichissement."
 
@@ -1866,7 +1856,7 @@ msgstr ""
 msgid "End field and start field can't be equal."
 msgstr "Le commencement et la fin ne peuvent être équivalent."
 
-#: pods/models.py:801 pods/templates/videos/video_enrich.html:419
+#: pods/models.py:801 pods/templates/videos/video_enrich.html:422
 msgid "There is an overlap with the enrichment "
 msgstr "Il y a un chevauchement avec l'enrichissement "
 
@@ -2107,11 +2097,11 @@ msgstr "Ajouter un nouvel enregistrement"
 #: pods/templates/videos/my_videos.html:24
 #: pods/templates/videos/my_videos.html:32
 #: pods/templates/videos/my_videos.html:43
-#: pods/templates/videos/video_chapter.html:335
-#: pods/templates/videos/video_completion.html:441
+#: pods/templates/videos/video_chapter.html:340
+#: pods/templates/videos/video_completion.html:440
 #: pods/templates/videos/video_delete.html:35
 #: pods/templates/videos/video_edit.html:217
-#: pods/templates/videos/video_enrich.html:442
+#: pods/templates/videos/video_enrich.html:445
 msgid "My videos"
 msgstr "Mes vidéos"
 
@@ -2342,214 +2332,214 @@ msgstr "Regarder"
 msgid "Delete the video."
 msgstr "Supprimer la vidéo."
 
-#: pods/templates/videos/video.html:45 pods/templates/videos/video.html:78
-#: pods/templates/videos/video_chapter.html:179
-#: pods/templates/videos/video_chapter.html:205
-#: pods/templates/videos/video_chapter.html:244
-#: pods/templates/videos/video_enrich.html:180
-#: pods/templates/videos/video_enrich.html:206
-#: pods/templates/videos/video_enrich.html:244
+#: pods/templates/videos/video.html:44 pods/templates/videos/video.html:75
+#: pods/templates/videos/video_chapter.html:184
+#: pods/templates/videos/video_chapter.html:210
+#: pods/templates/videos/video_chapter.html:249
+#: pods/templates/videos/video_enrich.html:183
+#: pods/templates/videos/video_enrich.html:209
+#: pods/templates/videos/video_enrich.html:247
 msgid "You are no longer authenticated. Please log in again."
 msgstr "Vous n'êtes plus authentifié. Veuillez vous reconnecter."
 
-#: pods/templates/videos/video.html:51 pods/templates/videos/video.html:98
+#: pods/templates/videos/video.html:49 pods/templates/videos/video.html:94
 msgid "Error sending information."
 msgstr "Erreur lors de l'envoi des informations."
 
-#: pods/templates/videos/video.html:51 pods/templates/videos/video.html:98
+#: pods/templates/videos/video.html:49 pods/templates/videos/video.html:94
 msgid "No data could be given."
 msgstr "Aucune données récupérées."
 
-#: pods/templates/videos/video.html:178
+#: pods/templates/videos/video.html:171
 msgid "This video is protected by password, please fill in and click send."
 msgstr ""
 "Cette vidéo est protégée par mot de passe, merci de le renseigner et de "
 "cliquer sur « Envoyer »."
 
-#: pods/templates/videos/video.html:182
+#: pods/templates/videos/video.html:175
 msgid "Password requiered"
 msgstr "Mot de passe requis"
 
-#: pods/templates/videos/video.html:191
+#: pods/templates/videos/video.html:184
 msgid "If you do not have the password or if you have connection problems"
 msgstr ""
 "Si vous n'avez pas le mot de passe ou si vous avez des problèmes de connexion"
 
-#: pods/templates/videos/video.html:212 pods/templates/videos/video.html:214
+#: pods/templates/videos/video.html:205 pods/templates/videos/video.html:207
 msgid "favorite"
 msgstr "favoris"
 
-#: pods/templates/videos/video.html:217 pods/templates/videos/video.html:219
+#: pods/templates/videos/video.html:210 pods/templates/videos/video.html:212
 msgid "Add to your favorites videos."
 msgstr "ajouter à vos vidéos favorites."
 
-#: pods/templates/videos/video.html:228 pods/templates/videos/video.html:230
+#: pods/templates/videos/video.html:221 pods/templates/videos/video.html:223
 msgid "You have already reported this video."
 msgstr "Vous avez déjà signalé cette vidéo."
 
-#: pods/templates/videos/video.html:235 pods/templates/videos/video.html:237
+#: pods/templates/videos/video.html:228 pods/templates/videos/video.html:230
 msgid "Report this video."
 msgstr "Signaler cette vidéo."
 
-#: pods/templates/videos/video.html:249
+#: pods/templates/videos/video.html:242
 msgid "You must be logged in to add this video to your favorites."
 msgstr "Vous devez être connecté pour ajouter cette vidéo à vos favoris."
 
-#: pods/templates/videos/video.html:254
+#: pods/templates/videos/video.html:247
 msgid "You must be logged in to report inappropriate content."
 msgstr "Vous devez être connecté pour signaler cette vidéo."
 
-#: pods/templates/videos/video.html:269
+#: pods/templates/videos/video.html:262
 msgid "Summary"
 msgstr "Résumé"
 
-#: pods/templates/videos/video.html:275
+#: pods/templates/videos/video.html:268
 msgid "Infos"
 msgstr "Informations"
 
-#: pods/templates/videos/video.html:282
+#: pods/templates/videos/video.html:275
 msgid "Downloads"
 msgstr "Télécharger"
 
-#: pods/templates/videos/video.html:290
+#: pods/templates/videos/video.html:283
 msgid "Embed/Share"
 msgstr "Intégrer / Partager"
 
-#: pods/templates/videos/video.html:332
+#: pods/templates/videos/video.html:325
 msgid "Number of view(s)"
 msgstr "Nombre de vues"
 
-#: pods/templates/videos/video.html:352
+#: pods/templates/videos/video.html:345
 msgid "Updated on"
 msgstr "Mise en ligne le"
 
-#: pods/templates/videos/video.html:357
+#: pods/templates/videos/video.html:350
 msgid "Contributor(s): writers, directors, editors, designers…"
 msgstr "Contributeur(s) : scénaristes, réalisateurs, éditeurs, concepteurs…"
 
-#: pods/templates/videos/video.html:362
+#: pods/templates/videos/video.html:355
 msgid "send an email"
 msgstr "envoyer un courriel"
 
-#: pods/templates/videos/video.html:370
+#: pods/templates/videos/video.html:363
 msgid "go to his web link"
 msgstr "se rendre à cette adresse web"
 
-#: pods/templates/videos/video.html:384
+#: pods/templates/videos/video.html:377
 msgid "Download the video"
 msgstr "Télécharger la vidéo"
 
-#: pods/templates/videos/video.html:422
+#: pods/templates/videos/video.html:415
 msgid "Social Networks"
 msgstr "Réseaux Sociaux"
 
-#: pods/templates/videos/video.html:434
+#: pods/templates/videos/video.html:427
 msgid "Copy the content of the text box and paste it in the page"
 msgstr "Copiez le contenu de la zone de texte et coller le dans la page"
 
-#: pods/templates/videos/video.html:440
+#: pods/templates/videos/video.html:433
 msgid "Video size"
 msgstr "Taille"
 
-#: pods/templates/videos/video.html:451
+#: pods/templates/videos/video.html:444
 msgid "Autoplay"
 msgstr "Lecture automatique"
 
-#: pods/templates/videos/video.html:458
+#: pods/templates/videos/video.html:451
 msgid "Use this link to share the video"
 msgstr "Utilisez ce lien pour partager la vidéo"
 
-#: pods/templates/videos/video.html:464
+#: pods/templates/videos/video.html:457
 msgid "Start video"
 msgstr "Début de la vidéo"
 
-#: pods/templates/videos/video.html:467
+#: pods/templates/videos/video.html:460
 msgid "Check the box to indicate the beginning of playing desired."
 msgstr "Cochez la case pour indiquer le début de lecture souhaité."
 
-#: pods/templates/videos/video.html:497
+#: pods/templates/videos/video.html:490
 msgid "You must be logged in to take notes."
 msgstr "Vous devez être connecté pour prendre des notes."
 
-#: pods/templates/videos/video.html:506
-#: pods/templates/videos/video_chapter.html:369
-#: pods/templates/videos/video_completion.html:515
-#: pods/templates/videos/video_enrich.html:474
+#: pods/templates/videos/video.html:499
+#: pods/templates/videos/video_chapter.html:374
+#: pods/templates/videos/video_completion.html:514
+#: pods/templates/videos/video_enrich.html:477
 msgid "Edit the video"
 msgstr "Modifier la vidéo"
 
 #: pods/templates/videos/video_chapter.html:29
-#: pods/templates/videos/video_chapter.html:325
-#: pods/templates/videos/video_chapter.html:336
+#: pods/templates/videos/video_chapter.html:330
+#: pods/templates/videos/video_chapter.html:341
 msgid "Chaptering the video"
 msgstr "Chapitrer la vidéo "
 
-#: pods/templates/videos/video_chapter.html:188
-#: pods/templates/videos/video_enrich.html:189
+#: pods/templates/videos/video_chapter.html:193
+#: pods/templates/videos/video_enrich.html:192
 msgid "Error getting form."
 msgstr "Erreur lors de la récupération du formulaire."
 
-#: pods/templates/videos/video_chapter.html:188
-#: pods/templates/videos/video_enrich.html:189
+#: pods/templates/videos/video_chapter.html:193
+#: pods/templates/videos/video_enrich.html:192
 msgid "The form could not be recovered."
 msgstr "Le formulaire n'a pu être rechargé."
 
-#: pods/templates/videos/video_chapter.html:197
+#: pods/templates/videos/video_chapter.html:202
 msgid "Are you sure you want to delete this chapter?"
 msgstr "Etes-vous sûr de vouloir supprimer ce chapitre ?"
 
-#: pods/templates/videos/video_chapter.html:210
-#: pods/templates/videos/video_enrich.html:211
+#: pods/templates/videos/video_chapter.html:215
+#: pods/templates/videos/video_enrich.html:214
 msgid "Error during deletion."
 msgstr "Erreur lors de la suppression."
 
-#: pods/templates/videos/video_chapter.html:210
-#: pods/templates/videos/video_completion.html:279
-#: pods/templates/videos/video_enrich.html:211
+#: pods/templates/videos/video_chapter.html:215
+#: pods/templates/videos/video_completion.html:278
+#: pods/templates/videos/video_enrich.html:214
 msgid "No data could be deleted."
 msgstr "Aucune données n'a pu être supprimée."
 
-#: pods/templates/videos/video_chapter.html:249
-#: pods/templates/videos/video_enrich.html:249
+#: pods/templates/videos/video_chapter.html:254
+#: pods/templates/videos/video_enrich.html:252
 msgid "Error during recording."
 msgstr "Erreur lors de l'enregistrement."
 
-#: pods/templates/videos/video_chapter.html:249
-#: pods/templates/videos/video_completion.html:317
-#: pods/templates/videos/video_enrich.html:249
+#: pods/templates/videos/video_chapter.html:254
+#: pods/templates/videos/video_completion.html:316
+#: pods/templates/videos/video_enrich.html:252
 msgid "No data could be stored."
 msgstr "Aucune donnée n'a pu être enregistrée."
 
-#: pods/templates/videos/video_chapter.html:269
-#: pods/templates/videos/video_enrich.html:273 pods/views.py:178
-#: pods/views.py:415 pods/views.py:607 pods/views.py:609 pods/views.py:665
+#: pods/templates/videos/video_chapter.html:274
+#: pods/templates/videos/video_enrich.html:276 pods/views.py:181
+#: pods/views.py:418 pods/views.py:610 pods/views.py:612 pods/views.py:672
 msgid "The changes have been saved."
 msgstr "Les modifications ont été enregistrées."
 
-#: pods/templates/videos/video_chapter.html:281
+#: pods/templates/videos/video_chapter.html:286
 msgid "Please enter a correct start field between 0 and"
 msgstr ""
 "Veuillez renseigner une valeur de début d’enrichissement comprise entre 0 et"
 
-#: pods/templates/videos/video_chapter.html:293
+#: pods/templates/videos/video_chapter.html:298
 msgid "The chapter"
 msgstr "Le chapitre"
 
-#: pods/templates/videos/video_chapter.html:293
+#: pods/templates/videos/video_chapter.html:298
 msgid "starts at the same time."
 msgstr "commence en même temps."
 
-#: pods/templates/videos/video_chapter.html:305
-#: pods/templates/videos/video_enrich.html:281
-#: pods/templates/videos/video_enrich.html:283
+#: pods/templates/videos/video_chapter.html:310
+#: pods/templates/videos/video_enrich.html:284
+#: pods/templates/videos/video_enrich.html:286
 msgid "Get time from the player"
 msgstr "Récupérer le temps depuis le lecteur"
 
-#: pods/templates/videos/video_chapter.html:361
+#: pods/templates/videos/video_chapter.html:366
 msgid "Add a new chapter"
 msgstr "Ajouter un nouveau chapitre"
 
-#: pods/templates/videos/video_chapter.html:377
+#: pods/templates/videos/video_chapter.html:382
 msgid ""
 "\"Add a new chapter\" allows you to add a new chapter, \"modify\" allows you "
 "to modify it and \"delete\" allows you to remove the chapter."
@@ -2558,7 +2548,7 @@ msgstr ""
 "\"modifier\" permet de le modifier et \"supprimer\" vous permet de le "
 "supprimer."
 
-#: pods/templates/videos/video_chapter.html:378
+#: pods/templates/videos/video_chapter.html:383
 msgid ""
 "Start playback of the video, pause the video and click on \"Get time from "
 "the player\" to fill in the field intitled \"Start time\"."
@@ -2567,17 +2557,17 @@ msgstr ""
 "le temps depuis le lecteur\" pour renseigner automatiquement le champ "
 "\"début du chapitre\"."
 
-#: pods/templates/videos/video_chapter.html:379
+#: pods/templates/videos/video_chapter.html:384
 msgid "The chapters cannot start at the same time."
 msgstr "Les chapitres ne peuvent pas commencer en même temps."
 
-#: pods/templates/videos/video_chapter.html:380
+#: pods/templates/videos/video_chapter.html:385
 msgid "You must save your chapters to view the result."
 msgstr "Vous devez sauvegarder pour visualiser le résultat."
 
 #: pods/templates/videos/video_completion.html:29
-#: pods/templates/videos/video_completion.html:431
-#: pods/templates/videos/video_completion.html:442
+#: pods/templates/videos/video_completion.html:430
+#: pods/templates/videos/video_completion.html:441
 msgid "Completion video"
 msgstr "Complétion de la vidéo "
 
@@ -2589,134 +2579,134 @@ msgstr "Cacher"
 msgid "Display"
 msgstr "Afficher"
 
-#: pods/templates/videos/video_completion.html:243
-#: pods/templates/videos/video_completion.html:274
-#: pods/templates/videos/video_completion.html:312
+#: pods/templates/videos/video_completion.html:242
+#: pods/templates/videos/video_completion.html:273
+#: pods/templates/videos/video_completion.html:311
 msgid "You are no longer authenticated. Please log in again"
 msgstr "Vous n'êtes plus authentifié. Veuillez vous reconnecter."
 
-#: pods/templates/videos/video_completion.html:251
+#: pods/templates/videos/video_completion.html:250
 msgid "Error getting form. "
 msgstr "Erreur lors de la récupération du formulaire."
 
-#: pods/templates/videos/video_completion.html:251
+#: pods/templates/videos/video_completion.html:250
 msgid "the form could not be recovered"
 msgstr "Le formulaire n'a pu être rechargé."
 
-#: pods/templates/videos/video_completion.html:260
-msgid "Are you sure you want to delete this file ?"
+#: pods/templates/videos/video_completion.html:259
+msgid "Are you sure you want to delete this file?"
 msgstr "Etes-vous sûr de vouloir supprimer ce fichier ?"
 
-#: pods/templates/videos/video_completion.html:262
-msgid "Are you sure you want to delete this contributor ?"
+#: pods/templates/videos/video_completion.html:261
+msgid "Are you sure you want to delete this contributor?"
 msgstr "Etes-vous sûr de vouloir supprimer ce contributeur ?"
 
-#: pods/templates/videos/video_completion.html:264
-msgid "Are you sure you want to delete this download ?"
+#: pods/templates/videos/video_completion.html:263
+msgid "Are you sure you want to delete this download?"
 msgstr "Etes-vous sûr de vouloir supprimer ce document à télécharger ?"
 
-#: pods/templates/videos/video_completion.html:279
+#: pods/templates/videos/video_completion.html:278
 msgid "Error deleting. "
 msgstr "Erreur lors de la suppression."
 
-#: pods/templates/videos/video_completion.html:309
-#: pods/templates/videos/video_enrich.html:241
+#: pods/templates/videos/video_completion.html:308
+#: pods/templates/videos/video_enrich.html:244
 msgid "Changes have been saved."
 msgstr "Les modifications ont été enregistrées."
 
-#: pods/templates/videos/video_completion.html:317
+#: pods/templates/videos/video_completion.html:316
 msgid "Error recording. "
 msgstr "Erreur lors de l'enregistrement."
 
-#: pods/templates/videos/video_completion.html:321
+#: pods/templates/videos/video_completion.html:320
 msgid "Errors found in the form, please correct it."
 msgstr ""
 "Des erreurs ont été trouvées dans le formulaire. Veuillez les corriger."
 
-#: pods/templates/videos/video_completion.html:336
+#: pods/templates/videos/video_completion.html:335
 msgid "Display '+ name_section + ' section"
 msgstr "Afficher la section  '+ name_section + ' "
 
-#: pods/templates/videos/video_completion.html:359
+#: pods/templates/videos/video_completion.html:358
 msgid "Please enter a name from 2 to 100 caracteres."
 msgstr "Veuillez renseigner un nom contenant entre 2 et 100 caractères."
 
-#: pods/templates/videos/video_completion.html:364
+#: pods/templates/videos/video_completion.html:363
 msgid "You cannot enter a weblink with more than 200 caracteres."
 msgstr "les liens internet doivent être inférieur à 200 caractères."
 
-#: pods/templates/videos/video_completion.html:369
+#: pods/templates/videos/video_completion.html:368
 msgid "Please enter a role."
 msgstr "Veuillez renseigner un rôle."
 
-#: pods/templates/videos/video_completion.html:377
+#: pods/templates/videos/video_completion.html:376
 msgid ""
 "There is already a contributor with this same name and role in the list."
 msgstr "il y a déjà un contributeur avec le même nom et le même rôle."
 
-#: pods/templates/videos/video_completion.html:385
+#: pods/templates/videos/video_completion.html:384
 msgid "Please enter a correct kind."
 msgstr "Veuillez renseigner le type de piste (sous-titre ou légende)."
 
-#: pods/templates/videos/video_completion.html:390
+#: pods/templates/videos/video_completion.html:389
 msgid "Please enter a lang."
 msgstr "Veuillez renseigner une langue."
 
-#: pods/templates/videos/video_completion.html:395
+#: pods/templates/videos/video_completion.html:394
 msgid "Please specify a track file."
 msgstr "Veuillez indiquer un fichier de sous-titre ou de légende."
 
-#: pods/templates/videos/video_completion.html:404
+#: pods/templates/videos/video_completion.html:403
 msgid ""
 "There is already a subtitle with this same kind and language in the list."
 msgstr "il y a déjà un fichier de même type et de même langue"
 
-#: pods/templates/videos/video_completion.html:412
+#: pods/templates/videos/video_completion.html:411
 msgid "Please enter a document."
 msgstr "Veuillez renseigner un document."
 
-#: pods/templates/videos/video_completion.html:419
+#: pods/templates/videos/video_completion.html:418
 msgid ""
 "There is already a download with this same name of document in the list."
 msgstr "Il y a déjà un document à télécharger portant le même nom."
 
-#: pods/templates/videos/video_completion.html:449
+#: pods/templates/videos/video_completion.html:448
 msgid "Display &quot;Contributor(s)&quot; section"
 msgstr "Afficher la section des contributeurs"
 
-#: pods/templates/videos/video_completion.html:449
+#: pods/templates/videos/video_completion.html:448
 msgid "Contributor(s)"
 msgstr "Contributeurs"
 
-#: pods/templates/videos/video_completion.html:465
+#: pods/templates/videos/video_completion.html:464
 msgid "Add a new contributor"
 msgstr "Ajouter un nouveau contributeur"
 
-#: pods/templates/videos/video_completion.html:471
+#: pods/templates/videos/video_completion.html:470
 msgid "Display &quot;Subtitle(s) and Captions(s) &quot; section"
 msgstr "Afficher la section de sous-titre ou de légende"
 
-#: pods/templates/videos/video_completion.html:471
+#: pods/templates/videos/video_completion.html:470
 msgid "Subtitle(s) and caption(s)"
 msgstr "Sous-titre(s) et légende(s)"
 
-#: pods/templates/videos/video_completion.html:487
+#: pods/templates/videos/video_completion.html:486
 msgid "Add a new subtitle or caption file"
 msgstr "Ajouter un nouveau fichier de sous-titre ou de légende"
 
-#: pods/templates/videos/video_completion.html:491
+#: pods/templates/videos/video_completion.html:490
 msgid "Display &quot; Additional resource(s)&quot; section"
 msgstr "Afficher la section documents complémentaires"
 
-#: pods/templates/videos/video_completion.html:491
+#: pods/templates/videos/video_completion.html:490
 msgid "Additional resource(s)"
 msgstr "Document(s) complémentaire(s)"
 
-#: pods/templates/videos/video_completion.html:506
+#: pods/templates/videos/video_completion.html:505
 msgid "Add a new additional resource"
 msgstr "Ajouter un nouveau document à télécharger"
 
-#: pods/templates/videos/video_completion.html:524
+#: pods/templates/videos/video_completion.html:523
 msgid ""
 "Several web sites allows you to subtitle or caption videos (for example: "
 "Amara)."
@@ -2724,7 +2714,7 @@ msgstr ""
 "Plusieurs sites Web offrent des outils pour sous-titrer ou légender des "
 "vidéos (Par exemple : Amara)."
 
-#: pods/templates/videos/video_completion.html:525
+#: pods/templates/videos/video_completion.html:524
 msgid ""
 "You can add several subtitle or caption files to a single video (for "
 "example, in order to subtitle or caption this video in several languages)."
@@ -2732,7 +2722,7 @@ msgstr ""
 "Vous pouvez ajouter plusieurs fichiers de sous-titre ou de légende pour une "
 "même vidéo (par exemple, vous pouvez sous-titrer en plusieurs langues)."
 
-#: pods/templates/videos/video_completion.html:526
+#: pods/templates/videos/video_completion.html:525
 msgid ""
 "For this purpose, you will need the URL of your video. This URL is a direct "
 "access to this video. Please do not communicate it outside of this site in "
@@ -2743,7 +2733,7 @@ msgstr ""
 "Eviter de la communiquer en dehors de ce site pour éviter tout "
 "téléchargement et utilisation abusive."
 
-#: pods/templates/videos/video_completion.html:530
+#: pods/templates/videos/video_completion.html:529
 msgid ""
 "Your current permissions do not allow you to add subtitle files or documents "
 "to download videos. Please contact us to add these rights."
@@ -2825,43 +2815,38 @@ msgstr ""
 msgid "Please come back tomorrow!"
 msgstr "Merci de revenir demain !"
 
-#: pods/templates/videos/video_edit.html:299
-msgid "Save and go back to previous page"
-msgstr "Enregistrer et revenir à la page précédente"
-
-#: pods/templates/videos/video_edit.html:300
+#: pods/templates/videos/video_edit.html:298
 msgid "Save and return to the previous page"
 msgstr "Enregistrer et revenir à la page précédente"
 
-#: pods/templates/videos/video_edit.html:303
-#: pods/templates/videos/video_edit.html:304
+#: pods/templates/videos/video_edit.html:301
 msgid "Save and watch the video"
 msgstr "Enregistrer et voir la vidéo"
 
-#: pods/templates/videos/video_edit.html:314
+#: pods/templates/videos/video_edit.html:311
 msgid "Sending, please wait."
 msgstr "Envoi en cours, merci de patienter."
 
-#: pods/templates/videos/video_edit.html:320
+#: pods/templates/videos/video_edit.html:317
 msgid "The page will refresh after the upload completes."
 msgstr "La page sera actualisée lorsque le téléversement sera terminé."
 
-#: pods/templates/videos/video_edit.html:345
+#: pods/templates/videos/video_edit.html:342
 msgid "Uploading"
 msgstr "Téléversement"
 
-#: pods/templates/videos/video_edit.html:348
+#: pods/templates/videos/video_edit.html:345
 #, python-format
 msgid "The file size must be lower than %(MAX_UPLOAD_FILE_SIZE)s."
 msgstr "La taille du fichier doit être inférieure à %(MAX_UPLOAD_FILE_SIZE)s."
 
-#: pods/templates/videos/video_edit.html:350
+#: pods/templates/videos/video_edit.html:347
 #, python-format
 msgid "You can upload up to %(MAX_DAILY_USER_UPLOADS)s files per day."
 msgstr ""
 "Vous pouvez téléverser jusqu’à %(MAX_DAILY_USER_UPLOADS)s fichiers par jour."
 
-#: pods/templates/videos/video_edit.html:352
+#: pods/templates/videos/video_edit.html:349
 msgid ""
 "The sending time depends on the size of your file and your upload speed. "
 "This can be quite long."
@@ -2869,7 +2854,7 @@ msgstr ""
 "Le temps d'envoi dépend de la taille de votre fichier et de votre vitesse de "
 "transfert. Cela peut être assez long."
 
-#: pods/templates/videos/video_edit.html:353
+#: pods/templates/videos/video_edit.html:350
 msgid ""
 "While sending your file, do not close your browser until you have received a "
 "message of success or failure."
@@ -2877,19 +2862,19 @@ msgstr ""
 "Pendant l'envoi de votre fichier, ne fermez pas votre navigateur avant "
 "d'avoir reçu un message de succès ou d'échec."
 
-#: pods/templates/videos/video_edit.html:358
+#: pods/templates/videos/video_edit.html:355
 msgid "File format"
 msgstr "Format de fichier"
 
-#: pods/templates/videos/video_edit.html:361
+#: pods/templates/videos/video_edit.html:358
 msgid "You can send an audio or video file."
 msgstr "Vous pouvez envoyer un fichier audio ou vidéo."
 
-#: pods/templates/videos/video_edit.html:362
+#: pods/templates/videos/video_edit.html:359
 msgid "The following formats are supported:"
 msgstr "Les formats suivants sont supportés :"
 
-#: pods/templates/videos/video_edit.html:370
+#: pods/templates/videos/video_edit.html:367
 msgid ""
 "In “Draft mode”, the content shows nowhere and nobody else but you can see "
 "it."
@@ -2897,18 +2882,18 @@ msgstr ""
 "En mode « Brouillon », le contenu n’apparaît nulle part et personne d’autre "
 "que vous ne le voit."
 
-#: pods/templates/videos/video_edit.html:378
-#: pods/templates/videos/video_edit.html:388
+#: pods/templates/videos/video_edit.html:375
+#: pods/templates/videos/video_edit.html:385
 msgid "If you don't select “Draft mode”,"
 msgstr "Si vous ne sélectionnez pas le mode « Brouillon »,"
 
-#: pods/templates/videos/video_edit.html:379
+#: pods/templates/videos/video_edit.html:376
 msgid "you can restrict the content access to only people belonging to"
 msgstr ""
 "vous pouvez restreindre l’accès à votre contenu aux seules personnes "
 "appartenant à"
 
-#: pods/templates/videos/video_edit.html:388
+#: pods/templates/videos/video_edit.html:385
 msgid ""
 "you can add a password which will be asked to anybody willing to watch your "
 "content."
@@ -2916,11 +2901,11 @@ msgstr ""
 "vous pouvez ajouter un mot de passe qui sera demandé à toute personne "
 "souhaitant visionner votre contenu."
 
-#: pods/templates/videos/video_edit.html:393
+#: pods/templates/videos/video_edit.html:390
 msgid "Keywords"
 msgstr "Mots-clés"
 
-#: pods/templates/videos/video_edit.html:396
+#: pods/templates/videos/video_edit.html:393
 msgid ""
 "Please try to add only relevant keywords that can be useful to other users."
 msgstr ""
@@ -2931,57 +2916,57 @@ msgstr ""
 msgid "Enrichment of the video"
 msgstr "Enrichissement de la vidéo"
 
-#: pods/templates/videos/video_enrich.html:198
+#: pods/templates/videos/video_enrich.html:201
 msgid "Are you sure you want to delete this enrichment?"
 msgstr "Etes-vous sûr de vouloir supprimer cet enrichissement ?"
 
-#: pods/templates/videos/video_enrich.html:330
+#: pods/templates/videos/video_enrich.html:333
 msgid "Please enter a correct start from 0 to "
 msgstr "Veuillez renseigner un commencement entre 0 et "
 
-#: pods/templates/videos/video_enrich.html:335
+#: pods/templates/videos/video_enrich.html:338
 msgid "Please enter a correct end from 1 to "
 msgstr "Veuillez renseigner une fin comprise entre 1 et "
 
-#: pods/templates/videos/video_enrich.html:362
+#: pods/templates/videos/video_enrich.html:365
 msgid "Weblink must be less than 200 characters."
 msgstr "les liens internet doivent être inférieur à 200 caractères."
 
-#: pods/templates/videos/video_enrich.html:382
+#: pods/templates/videos/video_enrich.html:385
 msgid "Embed field must be less than 300 characters."
 msgstr "Le code embed doit être inférieur à 300 caractères."
 
-#: pods/templates/videos/video_enrich.html:400
+#: pods/templates/videos/video_enrich.html:403
 msgid "The start field value is greater than the end field one."
 msgstr "La valeur de début ne peut être supérieur à celle de la fin."
 
-#: pods/templates/videos/video_enrich.html:402
+#: pods/templates/videos/video_enrich.html:405
 msgid "The end field value is greater than the video duration."
 msgstr "Ta valeur de fin d'enrichissement est supérieur à la durée de la vidéo"
 
-#: pods/templates/videos/video_enrich.html:404
+#: pods/templates/videos/video_enrich.html:407
 msgid "End field and start field cannot be equal."
 msgstr "Les valeurs de début et de fin ne peuvent être égales."
 
-#: pods/templates/videos/video_enrich.html:420
+#: pods/templates/videos/video_enrich.html:423
 msgid ", please change start and/or end values."
 msgstr ", veuillez modifier les valeurs de début et/ou de fin."
 
-#: pods/templates/videos/video_enrich.html:432
-#: pods/templates/videos/video_enrich.html:443
+#: pods/templates/videos/video_enrich.html:435
+#: pods/templates/videos/video_enrich.html:446
 msgid "Enrich video"
 msgstr "Enrichir la vidéo"
 
-#: pods/templates/videos/video_enrich.html:466
+#: pods/templates/videos/video_enrich.html:469
 msgid "Add a new enrichment"
 msgstr "Ajouter un nouvel enrichissement"
 
-#: pods/templates/videos/video_enrich.html:482
+#: pods/templates/videos/video_enrich.html:485
 msgid ""
 "The title fields is required and must contains from 2 to 100 characters."
 msgstr "Le titre est obligatoire et doit contenir entre 2 et 100 caractères."
 
-#: pods/templates/videos/video_enrich.html:483
+#: pods/templates/videos/video_enrich.html:486
 msgid ""
 "The fields \"Start\" and \"End\" must contain an indication value in "
 "seconds. Start playback of the video, pause the video and click on \"Get "
@@ -2994,11 +2979,11 @@ msgstr ""
 "l'enrichissement\". Faites de même pour renseigner le champ \"Fin de "
 "l'enrichissement\"."
 
-#: pods/templates/videos/video_enrich.html:484
+#: pods/templates/videos/video_enrich.html:487
 msgid "You cannot overlap enrichments."
 msgstr "Les enrichissements ne peuvent se chevaucher."
 
-#: pods/templates/videos/video_enrich.html:485
+#: pods/templates/videos/video_enrich.html:488
 msgid "You must save your enrichments to view the result."
 msgstr "Vous devez sauvegarder pour visualiser le résultat."
 
@@ -3028,35 +3013,35 @@ msgstr "Nouveau"
 msgid "-- sorry, no translation provided --"
 msgstr "-- désolé, aucune traduction disponible --"
 
-#: pods/views.py:161
+#: pods/views.py:164
 msgid "You cannot edit this channel."
 msgstr "Vous ne pouvez pas modifier cette chaîne."
 
-#: pods/views.py:400 pods/views.py:1407
+#: pods/views.py:403 pods/views.py:1414
 msgid "You cannot watch this video."
 msgstr "Vous ne pouvez pas regarder cette vidéo."
 
-#: pods/views.py:444
+#: pods/views.py:447
 msgid "Incorrect password"
 msgstr "Mot de passe incorrect"
 
-#: pods/views.py:504
+#: pods/views.py:507
 msgid "The video has been added to your favorites."
 msgstr "La vidéo a été ajoutée à vos vidéos favorites."
 
-#: pods/views.py:509
+#: pods/views.py:512
 msgid "The video has been removed from your favorites."
 msgstr "La vidéo a été supprimée de vos vidéos favorites."
 
-#: pods/views.py:518 pods/views.py:591 pods/views.py:613
+#: pods/views.py:521 pods/views.py:594 pods/views.py:616
 msgid "You cannot acces this page."
 msgstr "Vous ne pouvez pas accéder à cette page."
 
-#: pods/views.py:529
+#: pods/views.py:532
 msgid "Video report confirmation"
 msgstr "Confirmation de signalement de vidéo"
 
-#: pods/views.py:531
+#: pods/views.py:534
 #, python-format
 msgid ""
 "\n"
@@ -3075,7 +3060,7 @@ msgstr ""
 "Cordialement.\n"
 "L'équipe Pod."
 
-#: pods/views.py:536
+#: pods/views.py:539
 #, python-format
 msgid ""
 "<p>You just report the video: \"%(title)s\" with this comment:<br/> "
@@ -3086,11 +3071,11 @@ msgstr ""
 "<br/> \"%(comment)s\".</p><p>Un courriel vient de nous être envoyé et votre "
 "signalement enregistré.</p><p>Cordialement</p><p>L'équipe Pod</p>"
 
-#: pods/views.py:546
+#: pods/views.py:549
 msgid "A video has just been reported."
 msgstr "Une vidéo vient d'être signalée."
 
-#: pods/views.py:548
+#: pods/views.py:551
 #, python-format
 msgid ""
 "The video intitled \"%(video_title)s\" has just been reported by "
@@ -3114,7 +3099,7 @@ msgstr ""
 "%(owner_email)s>.\n"
 "Vidéo mise en ligne le : %(video_date_added)s.\n"
 
-#: pods/views.py:562
+#: pods/views.py:565
 #, python-format
 msgid ""
 "<p>The video intitled \"%(video_title)s\" has just been reported by "
@@ -3135,58 +3120,58 @@ msgstr ""
 "href=\"mailto:%(owner_email)s\">%(owner_email)s&gt;</a>.<br/>Vidéo mise en "
 "ligne le : %(video_date_added)s.</p>"
 
-#: pods/views.py:582
+#: pods/views.py:585
 msgid "This video has been reported."
 msgstr "La vidéo a été signalée."
 
-#: pods/views.py:633
+#: pods/views.py:640
 msgid "You cannot edit this video."
 msgstr "Vous ne pouvez pas éditer cette vidéo."
 
-#: pods/views.py:707 pods/views.py:741 pods/views.py:875 pods/views.py:1006
+#: pods/views.py:714 pods/views.py:748 pods/views.py:882 pods/views.py:1013
 msgid "You cannot complement this video."
 msgstr "Vous ne pouvez pas compléter cette vidéo."
 
-#: pods/views.py:799 pods/views.py:932 pods/views.py:1065
+#: pods/views.py:806 pods/views.py:939 pods/views.py:1072
 msgid "Please correct errors"
 msgstr "Veuillez corriger les erreurs."
 
-#: pods/views.py:1141
+#: pods/views.py:1148
 msgid "You cannot chapter this video."
 msgstr "Vous ne pouvez pas chapitrer cette vidéo."
 
-#: pods/views.py:1187 pods/views.py:1305
+#: pods/views.py:1194 pods/views.py:1312
 msgid "Please correct errors."
 msgstr "Veuillez corriger les erreurs."
 
-#: pods/views.py:1258
+#: pods/views.py:1265
 msgid "You cannot enrich this video."
 msgstr "Vous ne pouvez pas enrichir cette vidéo."
 
-#: pods/views.py:1369
+#: pods/views.py:1376
 msgid "You cannot delete this video."
 msgstr "Vous ne pouvez pas supprimer cette vidéo."
 
-#: pods/views.py:1385
+#: pods/views.py:1392
 msgid "The video has been deleted."
 msgstr "La vidéo a été supprimée."
 
-#: pods/views.py:1592
+#: pods/views.py:1599
 msgid "Mediapath should be indicated."
 msgstr "MediaPath doit être indiqué."
 
-#: pods/views.py:1616
+#: pods/views.py:1623
 msgid ""
 "Your publication is saved. Adding it to your videos will be in a few minutes."
 msgstr ""
 "Votre publication est enregistrée. Son ajout à vos vidéos se fera dans "
 "quelques minutes."
 
-#: pods/views.py:1673
+#: pods/views.py:1680
 msgid "Recording"
 msgstr "En cours d'enregistrement"
 
-#: pods/views.py:1675
+#: pods/views.py:1682
 #, python-format
 msgid ""
 "Hello, \n"
@@ -3212,7 +3197,7 @@ msgstr ""
 "\n"
 "Cordialement"
 
-#: pods/views.py:1679
+#: pods/views.py:1686
 #, python-format
 msgid ""
 "Hello, <p>a new mediacourse has just be added on %(title_site)s from the "
@@ -3226,6 +3211,9 @@ msgstr ""
 "%(link_url)s</a><br/><i>Si le lien n'est pas actif, il faut le copier-coller "
 "dans la barre d'adresse de votre navigateur.</i><p><p>Cordialement</p>"
 
-#: pods/views.py:1686
+#: pods/views.py:1693
 msgid "New mediacourse added."
 msgstr "Nouveaux médiacours ajoutés."
+
+#~ msgid "Save and go back to previous page"
+#~ msgstr "Enregistrer et revenir à la page précédente"


### PR DESCRIPTION
Gives to client-side generated alert boxes the same structure and behaviors than the Django-BootStrap ones:
- alert boxes dismiss (are generated on the fly then removed from markup after use),
- no more square buttons but a better visibility of the “close cross”,
- lighter and DRYer code with less event checking,
- various little fixes.

Needs a collectstatic, .po file replacement and .mo regeneration.