### PR TITLE
get_storage_path bug : use a more elegant way

### DIFF
--- a/pod_project/core/models.py
+++ b/pod_project/core/models.py
@@ -135,11 +135,9 @@ def create_user_profile(sender, instance, created, **kwargs):
             print msg
 
 def get_storage_path(instance, filename):
+    """ Get the storage path. Instance needs to implement owner """
     fname, dot, extension = filename.rpartition('.')
-    # check if instance is an EncodingPods or a Video
-    from pods.models import EncodingPods
-    username = instance.video.owner.username if isinstance(instance, EncodingPods) \
-        else instance.owner.username
+    username = instance.owner.username
     try:
         fname.index("/")
         return os.path.join(VIDEOS_DIR, username, '%s/%s.%s' % (os.path.dirname(fname), slugify(os.path.basename(fname)), extension))

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -477,6 +477,11 @@ class EncodingPods(models.Model):
     encodingFormat = models.CharField(
         _('Format'), max_length=12, choices=FORMAT_CHOICES, default="video/mp4")
 
+    @property
+    def owner(self):
+        """ return video owner """
+        return self.video.owner
+
     class Meta:
         verbose_name = _("encoding")
         verbose_name_plural = _("encodings")


### PR DESCRIPTION
En réfléchissant dans le train j'ai trouvé une manière plus élégante d'implémenter le correctif pour le bug de get_storage_path.

Plutôt que de tester la classe de l'instance dans get_storage_path, j'ai implémenté une propriété owner dans le modèle de EncodingPods.

