### PR TITLE
Feature: a channel can have multiple owners

### DIFF
--- a/pod_project/core/templates/header.html
+++ b/pod_project/core/templates/header.html
@@ -86,7 +86,7 @@ voir http://www.gnu.org/licenses/
                                         </a>
                                     </li>
                                 {% endif %}
-                                {% if request.user.owner_channels.all %}
+                                {% if request.user.owners_channels.all %}
                                     <li>
                                         <a href="{% url 'pods.views.owner_channels_list' %}">
                                             <span class="glyphicon glyphicon-th-large"></span>

--- a/pod_project/core/theme/LILLE1/assets/css/pod.css
+++ b/pod_project/core/theme/LILLE1/assets/css/pod.css
@@ -183,6 +183,9 @@ aside .form-group.show-all .more {
   max-height: 400px;
   overflow-y: auto;
 }
+.help-tooltip {
+  cursor: help;
+}
 /*******************************************************************************
 
         Video thumb
@@ -311,6 +314,50 @@ aside .form-group.show-all .more {
 #video_favorite_form {
   display: inline-block;
   vertical-align: middle;
+}
+/*******************************************************************************
+
+        Admin-like selector
+*/
+.form-group .selector select {
+  height: 8.7em;
+  width: 100%;
+  border: 1px solid #ccc;
+}
+.form-group .selector h2 {
+  margin: 0;
+  font-size: 1em;
+  line-height: 1.6em;
+  border: 1px solid #ccc;
+  border-bottom: 0 none;
+  background-color: #eee;
+  background-image: none;
+}
+.form-group .selector .selector-available,
+.form-group .selector .selector-chosen {
+  text-align: center;
+  margin-bottom: 5px;
+}
+.form-group .selector .selector-chosen {
+  border-top: 0 none;
+}
+.form-group .selector .selector-chooser {
+  list-style-type: none;
+}
+.form-group .selector .selector-filter {
+  background-color: #eee;
+  border: 1px solid #ccc;
+  border-width: 0 1px;
+  padding: 3px;
+  color: #999;
+  margin: 0;
+  text-align: left;
+}
+.form-group .selector .selector-filter input[type="text"] {
+  width: 92%;
+}
+.form-group .selector .btn-default:focus:not(:active) {
+  background-color: white;
 }
 /*******************************************************************************
 

--- a/pod_project/core/theme/LILLE1/less/includes/_pod.less
+++ b/pod_project/core/theme/LILLE1/less/includes/_pod.less
@@ -198,9 +198,17 @@ aside {
     margin-bottom: 10px;
 }
 
-[data-formset-body-contributor], [data-formset-body-chapter], [data-formset-body-track], [data-formset-body-doc], [data-formset-body] {
+[data-formset-body-contributor],
+[data-formset-body-chapter],
+[data-formset-body-track],
+[data-formset-body-doc],
+[data-formset-body] {
     max-height: 400px;
     overflow-y: auto;
+}
+
+.help-tooltip {
+    cursor: help;
 }
 
 
@@ -372,6 +380,66 @@ aside {
 #video_favorite_form {
     display: inline-block;
     vertical-align: middle;
+}
+
+
+
+/*******************************************************************************
+
+        Admin-like selector
+*/
+
+.form-group {
+
+    .selector {
+
+        select {
+            height: 8.7em;
+            width: 100%;
+            border: 1px solid #ccc;
+        }
+
+        h2 {
+            margin: 0;
+            font-size: 1em;
+            line-height: 1.6em;
+            border: 1px solid #ccc;
+            border-bottom: 0 none;
+            background-color: #eee;
+            background-image: none;
+        }
+
+        .selector-available, .selector-chosen {
+            text-align: center;
+            margin-bottom: 5px;
+        }
+
+        .selector-chosen {
+            border-top: 0 none;
+        }
+
+        .selector-chooser {
+            list-style-type: none;
+        }
+
+        .selector-filter {
+            background-color: #eee;
+            border: 1px solid #ccc;
+            border-width: 0 1px;
+            padding: 3px;
+            color: #999;
+            margin: 0;
+            text-align: left;
+
+            input[type="text"] {
+                width: 92%;
+            }
+        }
+
+        .btn-default:focus:not(:active) {
+            background-color: white;
+        }
+    }
 }
 
 

--- a/pod_project/pod_project/settings-sample.py
+++ b/pod_project/pod_project/settings-sample.py
@@ -230,6 +230,17 @@ MAX_DAILY_USER_UPLOADS = 0
 USE_XHR_FORM_UPLOAD = 1
 
 
+##
+# Possibilité pour les propriétaires de chaînes d'agir sur leur visibilité :
+#
+#   - ce paramètre est un entier ;
+#   - activation = 1, désactivation = 0 ;
+#   - si activé, le champ « Visible » est affiché dans le formulaire d'édition des chaînes.
+#
+#
+ALLOW_VISIBILITY_SETTING_TO_CHANNEL_OWNERS = 1
+
+
 # Paramètres des templates
 TEMPLATE_DIRS = (
     os.path.join(BASE_DIR, 'core', 'theme', TEMPLATE_THEME, 'templates'),

--- a/pod_project/pods/admin.py
+++ b/pod_project/pods/admin.py
@@ -34,7 +34,7 @@ from modeltranslation.admin import TranslationAdmin
 class ChannelAdmin(TranslationAdmin):
     list_display = ('title','visible',)
     prepopulated_fields = {'slug': ('title',)}
-    filter_horizontal = ('users',)
+    filter_horizontal = ('owners','users',)
     list_editable = ('visible', )
 admin.site.register(Channel, ChannelAdmin)
 

--- a/pod_project/pods/admin.py
+++ b/pod_project/pods/admin.py
@@ -32,7 +32,16 @@ User._meta.ordering=["username"]
 from modeltranslation.admin import TranslationAdmin
 
 class ChannelAdmin(TranslationAdmin):
-    list_display = ('title','visible',)
+
+    def get_owners(self, obj):
+        owners = []
+        for owner in obj.owners.all():
+            owners.append(u'%s %s (%s)' % (
+                owner.first_name, owner.last_name, owner.username))
+        return ', '.join(owners)
+
+    get_owners.short_description = _('Owners')
+    list_display = ('title','get_owners','visible',)
     prepopulated_fields = {'slug': ('title',)}
     filter_horizontal = ('owners','users',)
     list_editable = ('visible', )

--- a/pod_project/pods/admin.py
+++ b/pod_project/pods/admin.py
@@ -21,31 +21,45 @@ voir http://www.gnu.org/licenses/
 """
 from django.contrib import admin
 from pods.models import *
-from django import forms
+# from django import forms
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.admin import widgets
+# from django.contrib.admin import widgets
+
+from modeltranslation.admin import TranslationAdmin
+from django.core.urlresolvers import reverse
+from django.utils.html import format_html
 
 from django.contrib.auth.models import User
 #Ordering user by username !
-User._meta.ordering=["username"]
+User._meta.ordering = ["username"]
 
-from modeltranslation.admin import TranslationAdmin
+
+def url_to_edit_object(obj):
+    url = reverse(
+        'admin:%s_%s_change' % (obj._meta.app_label, obj._meta.model_name), args=[obj.id])
+    return format_html('<a href="{}">{}</a>', url, obj.__unicode__())
+
 
 class ChannelAdmin(TranslationAdmin):
 
     def get_owners(self, obj):
         owners = []
         for owner in obj.owners.all():
+            url = url_to_edit_object(owner)
             owners.append(u'%s %s (%s)' % (
-                owner.first_name, owner.last_name, owner.username))
+                owner.first_name, owner.last_name, url))
         return ', '.join(owners)
+    get_owners.allow_tags = True
 
     get_owners.short_description = _('Owners')
-    list_display = ('title','get_owners','visible',)
+    list_display = ('title', 'get_owners', 'visible',)
     prepopulated_fields = {'slug': ('title',)}
-    filter_horizontal = ('owners','users',)
+    filter_horizontal = ('owners', 'users',)
     list_editable = ('visible', )
+
+
 admin.site.register(Channel, ChannelAdmin)
+
 
 class ThemeAdmin(admin.ModelAdmin):
     list_display = ('title', 'channel')

--- a/pod_project/pods/forms.py
+++ b/pod_project/pods/forms.py
@@ -38,9 +38,18 @@ ALLOW_VISIBILITY_SETTING_TO_CHANNEL_OWNERS = getattr(
 class ChannelForm(TranslationModelForm):
 
     def __init__(self, *args, **kwargs):
+        user = kwargs.pop('user', None)
         super(ChannelForm, self).__init__(*args, **kwargs)
-        self.fields['users'].label_from_instance = lambda obj: "%s %s (%s)" % (
-            obj.first_name, obj.last_name, obj.username)
+        try:
+            if not user.is_staff:
+                del self.fields['headband']
+                del self.fields['users']
+            else:
+                self.fields['users'].label_from_instance = lambda obj: "%s %s (%s)" % (
+                    obj.first_name, obj.last_name, obj.username)
+        except:
+            del self.fields['headband']
+            del self.fields['users']
         for myField in self.fields:
             if self.fields[myField].required:
                 self.fields[myField].widget.attrs['class'] = 'required'

--- a/pod_project/pods/forms.py
+++ b/pod_project/pods/forms.py
@@ -6,7 +6,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -44,7 +44,7 @@ class ChannelForm(TranslationModelForm):
 
     class Meta:
         model = Channel
-        exclude = ('title', 'slug', 'owner', 'users')
+        exclude = ('title', 'slug', 'owners', 'users')
 
 
 class ThemeForm(ModelForm):

--- a/pod_project/pods/forms.py
+++ b/pod_project/pods/forms.py
@@ -34,10 +34,13 @@ from django.forms.widgets import HiddenInput
 ALLOW_VISIBILITY_SETTING_TO_CHANNEL_OWNERS = getattr(
     settings, 'ALLOW_VISIBILITY_SETTING_TO_CHANNEL_OWNERS', True)
 
+
 class ChannelForm(TranslationModelForm):
 
     def __init__(self, *args, **kwargs):
         super(ChannelForm, self).__init__(*args, **kwargs)
+        self.fields['users'].label_from_instance = lambda obj: "%s %s (%s)" % (
+            obj.first_name, obj.last_name, obj.username)
         for myField in self.fields:
             if self.fields[myField].required:
                 self.fields[myField].widget.attrs['class'] = 'required'

--- a/pod_project/pods/forms.py
+++ b/pod_project/pods/forms.py
@@ -23,6 +23,7 @@ import os
 from django import forms
 from django.forms import ModelForm, DateField, ValidationError, FileField, CharField, Form, PasswordInput
 from django.contrib.admin import widgets
+from django.contrib.auth.models import User
 from django.utils.safestring import mark_safe
 from itertools import chain
 from django.conf import settings
@@ -45,6 +46,7 @@ class ChannelForm(TranslationModelForm):
                 del self.fields['headband']
                 del self.fields['users']
             else:
+                self.fields['users'].queryset = User.objects.exclude(id=user.id)
                 self.fields['users'].label_from_instance = lambda obj: "%s %s (%s)" % (
                     obj.first_name, obj.last_name, obj.username)
         except:

--- a/pod_project/pods/forms.py
+++ b/pod_project/pods/forms.py
@@ -31,6 +31,9 @@ from pods.models import Channel, Theme, Pod, ContributorPods, TrackPods, DocPods
 from modeltranslation.forms import TranslationModelForm
 from django.forms.widgets import HiddenInput
 
+ALLOW_VISIBILITY_SETTING_TO_CHANNEL_OWNERS = getattr(
+    settings, 'ALLOW_VISIBILITY_SETTING_TO_CHANNEL_OWNERS', True)
+
 class ChannelForm(TranslationModelForm):
 
     def __init__(self, *args, **kwargs):
@@ -44,7 +47,10 @@ class ChannelForm(TranslationModelForm):
 
     class Meta:
         model = Channel
-        exclude = ('title', 'slug', 'owners')
+        if ALLOW_VISIBILITY_SETTING_TO_CHANNEL_OWNERS:
+            exclude = ('title', 'slug', 'owners')
+        else:
+            exclude = ('title', 'slug', 'owners', 'visible')
 
 
 class ThemeForm(ModelForm):

--- a/pod_project/pods/forms.py
+++ b/pod_project/pods/forms.py
@@ -44,7 +44,7 @@ class ChannelForm(TranslationModelForm):
 
     class Meta:
         model = Channel
-        exclude = ('title', 'slug', 'owners', 'users')
+        exclude = ('title', 'slug', 'owners')
 
 
 class ThemeForm(ModelForm):

--- a/pod_project/pods/forms.py
+++ b/pod_project/pods/forms.py
@@ -149,8 +149,8 @@ class PodForm(ModelForm):
         if not request.user.is_superuser:
             del self.fields['date_added']
             del self.fields['owner']
-            user_channels = request.user.owner_channels.all(
-            ) | request.user.users_channels.all()
+            user_channels = request.user.owners_channels.all(
+                ) | request.user.users_channels.all()
             if user_channels:
                 self.fields["channel"].queryset = user_channels
                 list_theme = Theme.objects.filter(

--- a/pod_project/pods/migrations/0010_channel_owners.py
+++ b/pod_project/pods/migrations/0010_channel_owners.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+def move_channel_owners_data(apps, schema_editor):
+
+    Channel = apps.get_model('pods', 'Channel')
+
+    for channel in Channel.objects.all():
+        channel.owners.add(channel.owner)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('pods', '0009_auto_20160708_1552'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='channel',
+            name='owners',
+            field=models.ManyToManyField(
+                related_name='owners_channels',
+                verbose_name='Owners',
+                to=settings.AUTH_USER_MODEL,
+                blank=True
+            ),
+        ),
+        migrations.RunPython(move_channel_owners_data),
+        migrations.RemoveField(
+            model_name='channel',
+            name='owner',
+        ),
+    ]

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -57,28 +57,30 @@ def remove_accents(input_str):
 @python_2_unicode_compatible
 class Channel(models.Model):
     title = models.CharField(_('Title'), max_length=100, unique=True)
-    slug = models.SlugField(_('Slug'), unique=True, max_length=100,
-                            help_text=_('Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'))
-
+    slug = models.SlugField(
+        _('Slug'), unique=True, max_length=100,
+        help_text=_(
+            u'Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'))
     description = RichTextField(
         _('Description'), config_name='complete', blank=True)
     headband = FilerImageField(
         null=True, blank=True, verbose_name=_('Headband'))
     color = models.CharField(
         _('Background color'), max_length=10, blank=True, null=True)
-
     style = models.TextField(_('Extra style'), null=True, blank=True)
-
-    owners = models.ManyToManyField(User, related_name='owners_channels', verbose_name=_('Owners'), blank=True)
-
-    users = models.ManyToManyField(User, related_name='users_channels',verbose_name=_('Users'),
-                                   help_text=_(
-                                       u'Hold down "Control", or "Command" on a Mac, to select more than one.'),
-                                   blank=True)
-    visible = models.BooleanField(verbose_name=_('Visible'),
-                                  help_text=_(
-                                      u'If checked, the channel appear in a list of available channels on the platform.'),
-                                  default=False)
+    owners = models.ManyToManyField(
+        User, related_name='owners_channels', verbose_name=_('Owners'),
+        blank=True)
+    users = models.ManyToManyField(
+        User, related_name='users_channels', verbose_name=_('Users'),
+        help_text=_(
+            u'Hold down "Control", or "Command" on a Mac, to select more than one.'),
+        blank=True)
+    visible = models.BooleanField(
+        verbose_name=_('Visible'),
+        help_text=_(
+            u'If checked, the channel appear in a list of available channels on the platform.'),
+        default=False)
 
     class Meta:
         ordering = ['title']
@@ -108,8 +110,10 @@ class Channel(models.Model):
 @python_2_unicode_compatible
 class Theme(models.Model):
     title = models.CharField(_('Title'), max_length=100, unique=True)
-    slug = models.SlugField(_('Slug'), unique=True, max_length=100,
-                            help_text=_('Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'))
+    slug = models.SlugField(
+        _('Slug'), unique=True, max_length=100,
+        help_text=_(
+            u'Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'))
     description = models.TextField(null=True, blank=True)
     headband = FilerImageField(
         null=True, blank=True, verbose_name=_('Headband'))
@@ -147,8 +151,10 @@ class Theme(models.Model):
 @python_2_unicode_compatible
 class Type(models.Model):
     title = models.CharField(_('Title'), max_length=100, unique=True)
-    slug = models.SlugField(_('Slug'), unique=True, max_length=100,
-                            help_text=_('Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'))
+    slug = models.SlugField(
+        _('Slug'), unique=True, max_length=100,
+        help_text=_(
+            u'Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'))
     description = models.TextField(null=True, blank=True)
     headband = FilerImageField(
         null=True, blank=True, verbose_name=_('Headband'))
@@ -181,8 +187,10 @@ class Type(models.Model):
 @python_2_unicode_compatible
 class Discipline(models.Model):
     title = models.CharField(_('title'), max_length=100, unique=True)
-    slug = models.SlugField(_('slug'), unique=True, max_length=100,
-                            help_text=_('Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'))
+    slug = models.SlugField(
+        _('slug'), unique=True, max_length=100,
+        help_text=_(
+            u'Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'))
     description = models.TextField(null=True, blank=True)
     headband = FilerImageField(
         null=True, blank=True, verbose_name=_('Headband'))
@@ -289,12 +297,10 @@ class _MyTaggableManager(_TaggableManager):
 
 @python_2_unicode_compatible
 class Pod(Video):
-
     tags = MyTaggableManager(
         help_text=_(
             u'Separate tags with spaces, enclose the tags consist of several words in quotation marks.'),
         verbose_name=_('Tags'), blank=True)
-
     type = models.ForeignKey(Type, verbose_name=_('Type'))
     discipline = models.ManyToManyField(
         Discipline, blank=True, verbose_name=_('Disciplines'))
@@ -305,12 +311,21 @@ class Pod(Video):
 
     #tags = TaggableManager(help_text=_(u'Séparez les tags par des espaces, mettez les tags constituées de plusieurs mots entre guillemets.'), verbose_name=_('Tags'), blank=True)
 
-    is_draft = models.BooleanField(verbose_name=_('Draft'), help_text=_(
-        u'If this box is checked, the video will be visible and accessible only by you.'), default=True)
-    is_restricted = models.BooleanField(verbose_name=_(u'Restricted access'), help_text=_(
-        u'If this box is checked, the video will only be accessible to authenticated users.'), default=False)
-    password = models.CharField(_('password'), help_text=_(
-        u'Viewing this video will not be possible without this password.'), max_length=50, blank=True, null=True)
+    is_draft = models.BooleanField(
+        verbose_name=_('Draft'),
+        help_text=_(
+            u'If this box is checked, the video will be visible and accessible only by you.'),
+        default=True)
+    is_restricted = models.BooleanField(
+        verbose_name=_(u'Restricted access'),
+        help_text=_(
+            u'If this box is checked, the video will only be accessible to authenticated users.'),
+        default=False)
+    password = models.CharField(
+        _('password'),
+        help_text=_(
+            u'Viewing this video will not be possible without this password.'),
+        max_length=50, blank=True, null=True)
 
     class Meta:
         verbose_name = _("Video")
@@ -683,18 +698,20 @@ class DocPods(models.Model):
 class EnrichPods(models.Model):
     video = models.ForeignKey(Pod, verbose_name=_('video'))
     title = models.CharField(_('title'), max_length=100)
-    slug = models.SlugField(_('slug'), unique=True, max_length=105,
-                            help_text=_(
-                                'Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'),
-                            editable=False)
-
+    slug = models.SlugField(
+        _('slug'), unique=True, max_length=105,
+        help_text=_(
+            u'Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'),
+        editable=False)
     #is_chapter = models.BooleanField(_('Is chapter ?'), default=False, help_text=_('Is chapter ?'))
     stop_video = models.BooleanField(_('Stop video'), default=False, help_text=_(
         'The video will pause when displaying this enrichment.'))
     start = models.PositiveIntegerField(
-        _('Start'), default=0, help_text=_('Start of enrichment display in seconds'))
+        _('Start'), default=0,
+        help_text=_('Start of enrichment display in seconds'))
     end = models.PositiveIntegerField(
-        _('End'), default=1, help_text=_('End of enrichment display in seconds'))
+        _('End'), default=1,
+        help_text=_('End of enrichment display in seconds'))
 
     ENRICH_CHOICES = (
         ("image", _("image")),
@@ -711,10 +728,14 @@ class EnrichPods(models.Model):
     richtext = RichTextField(_('richtext'), config_name='complete', blank=True)
     weblink = models.URLField(
         _(u'Web link'), max_length=200, null=True, blank=True)
-    document = FilerFileField(null=True, blank=True, verbose_name="Document", help_text=_(
-        'Integrate an document (PDF, text, html)'))
-    embed = models.TextField(_('Embed'), max_length=300, null=True, blank=True, help_text=_(
-        'Integrate an external source'))
+    document = FilerFileField(
+        null=True, blank=True, verbose_name="Document",
+        help_text=_(
+            u'Integrate an document (PDF, text, html)'))
+    embed = models.TextField(
+        _('Embed'), max_length=300, null=True, blank=True,
+        help_text=_(
+            u'Integrate an external source'))
 
     class Meta:
         verbose_name = _("Enrichment")
@@ -833,13 +854,14 @@ class EnrichPods(models.Model):
 class ChapterPods(models.Model):
     video = models.ForeignKey(Pod, verbose_name=_('video'))
     title = models.CharField(_('title'), max_length=100)
-    slug = models.SlugField(_('slug'), unique=True, max_length=105,
-                            help_text=_(
-                                'Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'),
-                            editable=False)
-
+    slug = models.SlugField(
+        _('slug'), unique=True, max_length=105,
+        help_text=_(
+            u'Used to access this instance, the "slug" is a short label containing only letters, numbers, underscore or dash top.'),
+        editable=False)
     time = models.PositiveIntegerField(
-        _('Start time'), default=0, help_text=_('Start time of the chapter, in seconds.'))
+        _('Start time'), default=0,
+        help_text=_(u'Start time of the chapter, in seconds.'))
 
     class Meta:
         verbose_name = _("Chapter")
@@ -978,7 +1000,8 @@ class Mediacourses(models.Model):
 class Building(models.Model):
     name = models.CharField(_('name'), max_length=200, unique=True)
     image = FilerImageField(
-        null=True, blank=True, verbose_name="Image", related_name="building_image")
+        null=True, blank=True, verbose_name="Image",
+        related_name="building_image")
 
     def __unicode__(self):
         return self.name
@@ -995,15 +1018,21 @@ class Building(models.Model):
 class Recorder(models.Model):
     name = models.CharField(_('name'), max_length=200, unique=True)
     building = models.ForeignKey('Building', verbose_name=_('Building'))
-    description = RichTextField(_('description'), config_name='complete', blank=True)
+    description = RichTextField(
+        _('description'), config_name='complete', blank=True)
     image = FilerImageField(
-        null=True, blank=True, verbose_name="Image", related_name="recorder_image")
+        null=True, blank=True, verbose_name="Image",
+        related_name="recorder_image")
     adress_ip = models.GenericIPAddressField(unique=True)
     status = models.BooleanField(default=0)
     slide = models.BooleanField(default=1)
     gmapurl = models.CharField(max_length=250, blank=True, null=True)
-    is_restricted = models.BooleanField(verbose_name=_(u'Restricted access'), help_text=_(
-        u'Live is accessible only to authenticated users.'), default=False)
+    is_restricted = models.BooleanField(
+        verbose_name=_(u'Restricted access'),
+        help_text=_(
+            u'Live is accessible only to authenticated users.'),
+        default=False)
+
     def __unicode__(self):
         return "%s - %s" % (self.name, self.adress_ip)
 

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -71,8 +71,10 @@ class Channel(models.Model):
 
     owners = models.ManyToManyField(User, related_name='owners_channels', verbose_name=_('Owners'), blank=True)
 
-    users = models.ManyToManyField(User, related_name='users_channels', verbose_name=_('Users'),
-                                  blank=True)
+    users = models.ManyToManyField(User, related_name='users_channels',verbose_name=_('Users'),
+                                   help_text=_(
+                                       u'Hold down "Control", or "Command" on a Mac, to select more than one.'),
+                                   blank=True)
     visible = models.BooleanField(verbose_name=_('Visible'),
                                   help_text=_(
                                       u'If checked, the channel appear in a list of available channels on the platform.'),

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -69,8 +69,7 @@ class Channel(models.Model):
 
     style = models.TextField(_('Extra style'), null=True, blank=True)
 
-    owner = models.ForeignKey(
-        User, related_name='owner_channels', verbose_name=_('Owner'))
+    owners = models.ManyToManyField(User, related_name='owners_channels', verbose_name=_('Owners'), blank=True)
 
     users = models.ManyToManyField(User, related_name='users_channels', verbose_name=_('Users'),
                                   blank=True)

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -73,8 +73,6 @@ class Channel(models.Model):
         blank=True)
     users = models.ManyToManyField(
         User, related_name='users_channels', verbose_name=_('Users'),
-        help_text=_(
-            u'Hold down "Control", or "Command" on a Mac, to select more than one.'),
         blank=True)
     visible = models.BooleanField(
         verbose_name=_('Visible'),

--- a/pod_project/pods/templates/channels/channel.html
+++ b/pod_project/pods/templates/channels/channel.html
@@ -87,7 +87,7 @@ voir http://www.gnu.org/licenses/
                     {% blocktrans count counter=videos.paginator.count %}{{ counter }} video{% plural %}{{ counter }} videos{% endblocktrans %}
                 </div>
             {% endif %}
-            {% if user.is_authenticated and channel.owner == request.user%}
+            {% if user.is_authenticated and request.user in channel.owners.all%}
                 <div class="resultschannel">
                     <a href="{% url 'channel_edit' slug_c=channel.slug %}" title="{% trans 'edit' %}">
                         <span class="glyphicon glyphicon-pencil"></span>

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -26,22 +26,60 @@ voir http://www.gnu.org/licenses/
 
 {% block bootstrap3_title %}{% trans "Edition of the channel" %} {{form.instance.title}}{% endblock %}
 {% block bootstrap3_extra_head %}
-        <!-- media -->
-        <script type="text/javascript">window.__admin_media_prefix__ = "/static/admin/";</script>
-        <script type="text/javascript" src="/admin/jsi18n/"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/admin/RelatedObjectLookups.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/actions.js"></script>
 
+        <!-- media -->
         <!-- form.media -->
         {{form.media}}
         <!-- {{formset.media}} -->
         <!-- {{docformset.media}} -->
-        <script type="text/javascript" src="{{ STATIC_URL }}filer/js/popup_handling.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}ckeditor/ckeditor/ckeditor.js"></script>
         <script src="{{ STATIC_URL }}js/jquery.formset.js"></script>
+
+        <!-- M2M select box
+        <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}admin/css/widgets.css" /> -->
+        <style>
+            .selector {
+            }
+            .selector select {
+                height: 8.7em;
+                width: 100%;
+            }
+            .selector h2 {
+                margin: 0;
+                font-size: 14px;
+                border: 1px solid #ccc;
+                background: white url({{ STATIC_URL }}admin/img/nav-bg.gif) bottom left repeat-x;
+            }
+            .selector-available, .selector-chosen {
+                text-align: center;
+                margin-bottom: 5px;
+            }
+            .selector-chooser {
+                list-style-type: none;
+            }
+            .selector .selector-filter {
+                background: white;
+                border: 1px solid #ccc;
+                border-width: 0 1px;
+                padding: 3px;
+                color: #999;
+                font-size: 10px;
+                margin: 0;
+                text-align: left;
+            }
+            .selector select {
+                border: 1px solid #ccc;
+            }
+            #id_users_input {
+                width: 92%;
+            }
+        </style>
+        <script type="text/javascript">window.__admin_media_prefix__ = "/static/admin/";</script>
+        <script type="text/javascript" src="/admin/jsi18n/"></script>
+        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>
+        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.js"></script>
+        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
+        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/SelectBox.js"></script>
+        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/SelectFilter2.js"></script>
 
 <script>
 var messageBeforeUnload = "{% trans "Warning, you will leave this page. If you have made changes without clicking the Save button, your changes will be lost." %}";
@@ -80,108 +118,125 @@ jQuery(function($) {
 
 <form method="post" action="{% url 'channel_edit' slug_c=form.instance.slug %}" id="channel_form">
 {% csrf_token %}
-<fieldset>
-<legend>{{form.instance.title}}</legend>
-{% bootstrap_form form %}
-<input type='hidden' name='referer' value='{{ referer }}' />
-</fieldset>
+    <fieldset>
+    <legend>{{form.instance.title}}</legend>
+    {% bootstrap_form form %}
+    <input type='hidden' name='referer' value='{{ referer }}' />
+    </fieldset>
 
-{% buttons %}
-<div class="text-center">
-    <button type="submit" class="btn btn-success" value="{% trans "Save" %}" name="action1">
-        {% bootstrap_icon "save" %} {% trans "Save" %}
-    </button>
-    <button type="submit" class="btn btn-success" value="{% trans "Save and return to previous page" %}" name="action2">
-        {% bootstrap_icon "save" %} {% trans "Save and return to previous page" %}
-    </button>
-    <button type="submit" class="btn btn-success" value="{% trans "Save and see channel" %}" name="action3">
-        {% bootstrap_icon "save" %} {% trans "Save and see channel" %}
-    </button>
-</div>
-{% endbuttons %}
-
-
-<fieldset id="themes">
-    <legend>{% trans "Themes" %}</legend>
-    <div id="formset" data-formset-prefix="{{ formset.prefix }}">
-        {{ formset.management_form }}
-
-        <div data-formset-body class="data-formset-body" >
-            <!-- New forms will be inserted in here -->
-            {% for form in formset %}
-                <div data-formset-form class="form-container" >
-                    {% for field_hidden in form.hidden_fields %}
-                    {{ field_hidden }}
-                    {% endfor %}
-                    {% for field in form.visible_fields %}
-                    {% if 'DELETE' in field.id_for_label %}
-                        <div class="form-group hide">
-                            <div class="checkbox">
-                                <label>
-                                    {{field.label_tag}} {{field}}
-                                </label>
-                            </div>
-                        </div>
-                    {% else %}
-                        {% bootstrap_field field %}
-                    {% endif %}
-                    {% endfor %}
-                    <button type="button" data-formset-delete-button class="btn btn-danger">{% trans "Delete" %}</button>
-                </div>
-            {% endfor %}
-        </div>
-
-        <!-- The empty form template. By wrapping this in a <script> tag, the
-        __prefix__ placeholder can easily be replaced in both attributes and
-        any scripts -->
-        <script type="form-template" data-formset-empty-form>
-            {% escapescript %}
-                <div data-formset-form class="form-container">
-                    {% for field_hidden in formset.empty_form.hidden_fields %}
-                    {{ field_hidden }}
-                    {% endfor %}
-                    {% for field in formset.empty_form.visible_fields %}
-                    {% if 'DELETE' in field.id_for_label %}
-                        <div class="form-group hide">
-                            <div class="checkbox">
-                                <label>
-                                    {{field.label_tag}} {{field}}
-                                </label>
-                            </div>
-                        </div>
-                    {% else %}
-                        {% bootstrap_field field %}
-                    {% endif %}
-                    {% endfor %}
-                    <button type="button" data-formset-delete-button class="btn btn-danger">{% trans "Delete" %}</button>
-                </div>
-            {% endescapescript %}
-        </script>
-
-        <!-- This button will add a new form when clicked -->
-        <p>&nbsp;</p>
-        <div class="text-center">
-        <button type="button" data-formset-add class="btn btn-info">{% trans "Add"%}</button>
-        </div>
-        <p>&nbsp;</p>
+    {% buttons %}
+    <div class="text-center">
+        <button type="submit" class="btn btn-success" value="{% trans "Save" %}" name="action1">
+            {% bootstrap_icon "save" %} {% trans "Save" %}
+        </button>
+        <button type="submit" class="btn btn-success" value="{% trans "Save and return to previous page" %}" name="action2">
+            {% bootstrap_icon "save" %} {% trans "Save and return to previous page" %}
+        </button>
+        <button type="submit" class="btn btn-success" value="{% trans "Save and see channel" %}" name="action3">
+            {% bootstrap_icon "save" %} {% trans "Save and see channel" %}
+        </button>
     </div>
-</fieldset>
+    {% endbuttons %}
 
-{% buttons %}
-<div class="text-center">
-    <button type="submit" class="btn btn-success" value="{% trans "Save" %}" name="action1">
-        {% bootstrap_icon "save" %} {% trans "Save" %}
-    </button>
-    <button type="submit" class="btn btn-success" value="{% trans "Save and return to previous page" %}" name="action2">
-        {% bootstrap_icon "save" %} {% trans "Save and return to previous page" %}
-    </button>
-    <button type="submit" class="btn btn-success" value="{% trans "Save and see channel" %}" name="action3">
-        {% bootstrap_icon "save" %} {% trans "Save and see channel" %}
-    </button>
-</div>
-{% endbuttons %}
 
-    </form>
+    <fieldset id="themes">
+        <legend>{% trans "Themes" %}</legend>
+        <div id="formset" data-formset-prefix="{{ formset.prefix }}">
+            {{ formset.management_form }}
+
+            <div data-formset-body class="data-formset-body" >
+                <!-- New forms will be inserted in here -->
+                {% for form in formset %}
+                    <div data-formset-form class="form-container" >
+                        {% for field_hidden in form.hidden_fields %}
+                        {{ field_hidden }}
+                        {% endfor %}
+                        {% for field in form.visible_fields %}
+                        {% if 'DELETE' in field.id_for_label %}
+                            <div class="form-group hide">
+                                <div class="checkbox">
+                                    <label>
+                                        {{field.label_tag}} {{field}}
+                                    </label>
+                                </div>
+                            </div>
+                        {% else %}
+                            {% bootstrap_field field %}
+                        {% endif %}
+                        {% endfor %}
+                        <button type="button" data-formset-delete-button class="btn btn-danger">{% trans "Delete" %}</button>
+                    </div>
+                {% endfor %}
+            </div>
+
+            <!-- The empty form template. By wrapping this in a <script> tag, the
+            __prefix__ placeholder can easily be replaced in both attributes and
+            any scripts -->
+            <script type="form-template" data-formset-empty-form>
+                {% escapescript %}
+                    <div data-formset-form class="form-container">
+                        {% for field_hidden in formset.empty_form.hidden_fields %}
+                        {{ field_hidden }}
+                        {% endfor %}
+                        {% for field in formset.empty_form.visible_fields %}
+                        {% if 'DELETE' in field.id_for_label %}
+                            <div class="form-group hide">
+                                <div class="checkbox">
+                                    <label>
+                                        {{field.label_tag}} {{field}}
+                                    </label>
+                                </div>
+                            </div>
+                        {% else %}
+                            {% bootstrap_field field %}
+                        {% endif %}
+                        {% endfor %}
+                        <button type="button" data-formset-delete-button class="btn btn-danger">{% trans "Delete" %}</button>
+                    </div>
+                {% endescapescript %}
+            </script>
+
+            <!-- This button will add a new form when clicked -->
+            <p>&nbsp;</p>
+            <div class="text-center">
+            <button type="button" data-formset-add class="btn btn-info">{% trans "Add"%}</button>
+            </div>
+            <p>&nbsp;</p>
+        </div>
+    </fieldset>
+
+    {% buttons %}
+    <div class="text-center">
+        <button type="submit" class="btn btn-success" value="{% trans "Save" %}" name="action1">
+            {% bootstrap_icon "save" %} {% trans "Save" %}
+        </button>
+        <button type="submit" class="btn btn-success" value="{% trans "Save and return to previous page" %}" name="action2">
+            {% bootstrap_icon "save" %} {% trans "Save and return to previous page" %}
+        </button>
+        <button type="submit" class="btn btn-success" value="{% trans "Save and see channel" %}" name="action3">
+            {% bootstrap_icon "save" %} {% trans "Save and see channel" %}
+        </button>
+    </div>
+    {% endbuttons %}
+
+    <script type="text/javascript">
+        $( document ).ready(function( ) {
+            SelectFilter.init("id_users", "{% trans 'Utilisateurs' %}", 0, "{{ STATIC_URL }}admin/");
+            $('.selector').addClass('row');
+            $('.selector-available').addClass('col-sm-5');
+            $('.selector-chosen').addClass('col-sm-5');
+            $('.selector-chooser').addClass('col-sm-2');
+            $('.selector-chooser > li > a').addClass('center-block btn btn-sm btn-default');
+            $('.selector-chooseall').addClass('btn btn-default btn-sm');
+            $('.selector-clearall').addClass('btn btn-default btn-sm');
+            $('#id_users_add_all_link').append(' <i class="fa fa-arrow-right"></i>');
+            $('#id_users_remove_all_link').prepend('<i class="fa fa-arrow-left"></i> ');
+            $('#id_users_add_link').append(' <i class="fa fa-arrow-right"></i>');
+            $('#id_users_remove_link').prepend('<i class="fa fa-arrow-left"></i> ');
+        } );
+    </script>
+
+</form>
     {% endblock article_content %}
     {% block video_list %} {% endblock video_list %}
 {% endblock article %}
@@ -204,3 +259,4 @@ jQuery(function($) {
 {% endblock box_info %}
 </aside>
 {% endblock %}
+

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -27,73 +27,39 @@ voir http://www.gnu.org/licenses/
 {% block bootstrap3_title %}{% trans "Edition of the channel" %} {{form.instance.title}}{% endblock %}
 {% block bootstrap3_extra_head %}
 
-        <!-- media -->
-        <!-- form.media -->
-        {{form.media}}
-        <!-- {{formset.media}} -->
-        <!-- {{docformset.media}} -->
-        <script src="{{ STATIC_URL }}js/jquery.formset.js"></script>
+    <!-- media -->
+    <!-- form.media -->
+    {{form.media}}
+    <!-- {{formset.media}} -->
+    <!-- {{docformset.media}} -->
+    <script src="{{ STATIC_URL }}js/jquery.formset.js"></script>
 
-        <!-- M2M select box
-        <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}admin/css/widgets.css" /> -->
-        <style>
-            .selector {
-            }
-            .selector select {
-                height: 8.7em;
-                width: 100%;
-            }
-            .selector h2 {
-                margin: 0;
-                font-size: 14px;
-                border: 1px solid #ccc;
-                background: white url({{ STATIC_URL }}admin/img/nav-bg.gif) bottom left repeat-x;
-            }
-            .selector-available, .selector-chosen {
-                text-align: center;
-                margin-bottom: 5px;
-            }
-            .selector-chooser {
-                list-style-type: none;
-            }
-            .selector .selector-filter {
-                background: white;
-                border: 1px solid #ccc;
-                border-width: 0 1px;
-                padding: 3px;
-                color: #999;
-                font-size: 10px;
-                margin: 0;
-                text-align: left;
-            }
-            .selector select {
-                border: 1px solid #ccc;
-            }
-            #id_users_input {
-                width: 92%;
-            }
-        </style>
-        <script type="text/javascript">window.__admin_media_prefix__ = "/static/admin/";</script>
-        <script type="text/javascript" src="/admin/jsi18n/"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/SelectBox.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/SelectFilter2.js"></script>
+    <!-- Admin-like selector (channel users) -->
+    <style>
+        .selector h2 {
+            background: white url({{ STATIC_URL }}admin/img/nav-bg.gif) bottom left repeat-x;
+        }
+    </style>
+    <script type="text/javascript">window.__admin_media_prefix__ = "/static/admin/";</script>
+    <script type="text/javascript" src="/admin/jsi18n/"></script>
+    <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>
+    <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.js"></script>
+    <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
+    <script type="text/javascript" src="{{ STATIC_URL }}admin/js/SelectBox.js"></script>
+    <script type="text/javascript" src="{{ STATIC_URL }}admin/js/SelectFilter2.js"></script>
+    <!-- /Admin-like selector -->
 
-<script>
-var messageBeforeUnload = "{% trans "Warning, you will leave this page. If you have made changes without clicking the Save button, your changes will be lost." %}";
+    <script>
+        var messageBeforeUnload = "{% trans "Warning, you will leave this page. If you have made changes without clicking the Save button, your changes will be lost." %}";
+        var num = 0;
+        var name = "";
 
-var num=0;
-var name = "";
-
-jQuery(function($) {
-    $("#formset").formset({
-        animateForms: true
-    });
-});
-
-</script>
+        jQuery(function($) {
+            $("#formset").formset({
+                animateForms: true
+            });
+        });
+    </script>
 {% endblock bootstrap3_extra_head %}
 
 

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -118,7 +118,7 @@ voir http://www.gnu.org/licenses/
                             {% bootstrap_field field %}
                         {% endif %}
                         {% endfor %}
-                        <button type="button" data-formset-delete-button class="btn btn-danger">{% trans "Delete" %}</button>
+                        <button type="button" data-formset-delete-button class="btn btn-danger">{% trans "Delete this theme" %}</button>
                     </div>
                 {% endfor %}
             </div>
@@ -145,7 +145,7 @@ voir http://www.gnu.org/licenses/
                             {% bootstrap_field field %}
                         {% endif %}
                         {% endfor %}
-                        <button type="button" data-formset-delete-button class="btn btn-danger">{% trans "Delete" %}</button>
+                        <button type="button" data-formset-delete-button class="btn btn-danger">{% trans "Delete this theme" %}</button>
                     </div>
                 {% endescapescript %}
             </script>
@@ -153,7 +153,7 @@ voir http://www.gnu.org/licenses/
             <!-- This button will add a new form when clicked -->
             <p>&nbsp;</p>
             <div class="text-center">
-            <button type="button" data-formset-add class="btn btn-info">{% trans "Add"%}</button>
+            <button type="button" data-formset-add class="btn btn-info">{% trans "Add a new theme"%}</button>
             </div>
             <p>&nbsp;</p>
         </div>

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -186,13 +186,13 @@ voir http://www.gnu.org/licenses/
     {% endbuttons %}
 
     <script type="text/javascript">
-        $( document ).ready(function( ) {
+        $(document).ready(function() {
             SelectFilter.init("id_users", "{% trans 'Utilisateurs' %}", 0, "{{ STATIC_URL }}admin/");
             $('.selector').addClass('row');
             $('.selector-available').addClass('col-sm-5');
             $('.selector-chosen').addClass('col-sm-5');
             $('.selector-chooser').addClass('col-sm-2');
-            $('.selector-chooser > li > a').addClass('center-block btn btn-sm btn-default');
+            $('.selector-chooser > li > a').addClass('btn btn-sm btn-block btn-default');
             $('.selector-chooseall').addClass('btn btn-default btn-sm');
             $('.selector-clearall').addClass('btn btn-default btn-sm');
             $('#id_users_add_all_link').append(' <i class="fa fa-arrow-right"></i>');

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -93,21 +93,6 @@ voir http://www.gnu.org/licenses/
     <input type='hidden' name='referer' value='{{ referer }}' />
     </fieldset>
 
-    {% buttons %}
-    <div class="text-center">
-        <button type="submit" class="btn btn-success" value="{% trans "Save" %}" name="action1">
-            {% bootstrap_icon "save" %} {% trans "Save" %}
-        </button>
-        <button type="submit" class="btn btn-success" value="{% trans "Save and return to previous page" %}" name="action2">
-            {% bootstrap_icon "save" %} {% trans "Save and return to previous page" %}
-        </button>
-        <button type="submit" class="btn btn-success" value="{% trans "Save and see channel" %}" name="action3">
-            {% bootstrap_icon "save" %} {% trans "Save and see channel" %}
-        </button>
-    </div>
-    {% endbuttons %}
-
-
     <fieldset id="themes">
         <legend>{% trans "Themes" %}</legend>
         <div id="formset" data-formset-prefix="{{ formset.prefix }}">

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -27,13 +27,6 @@ voir http://www.gnu.org/licenses/
 {% block bootstrap3_title %}{% trans "Edition of the channel" %} {{form.instance.title}}{% endblock %}
 {% block bootstrap3_extra_head %}
 
-    <!-- media -->
-    <!-- form.media -->
-    {{form.media}}
-    <!-- {{formset.media}} -->
-    <!-- {{docformset.media}} -->
-    <script src="{{ STATIC_URL }}js/jquery.formset.js"></script>
-
     <!-- Admin-like selector (channel users) -->
     <style>
         .selector h2 {
@@ -48,6 +41,13 @@ voir http://www.gnu.org/licenses/
     <script type="text/javascript" src="{{ STATIC_URL }}admin/js/SelectBox.js"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}admin/js/SelectFilter2.js"></script>
     <!-- /Admin-like selector -->
+
+    <!-- media -->
+    <!-- form.media -->
+    {{form.media}}
+    <!-- {{formset.media}} -->
+    <!-- {{docformset.media}} -->
+    <script src="{{ STATIC_URL }}js/jquery.formset.js"></script>
 
     <script>
         var messageBeforeUnload = "{% trans "Warning, you will leave this page. If you have made changes without clicking the Save button, your changes will be lost." %}";

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -188,13 +188,13 @@ voir http://www.gnu.org/licenses/
     <script type="text/javascript">
         $(document).ready(function() {
             SelectFilter.init("id_users", "{% trans 'Utilisateurs' %}", 0, "{{ STATIC_URL }}admin/");
-            $('.selector').addClass('row');
-            $('.selector-available').addClass('col-sm-5');
-            $('.selector-chosen').addClass('col-sm-5');
-            $('.selector-chooser').addClass('col-sm-2');
-            $('.selector-chooser > li > a').addClass('btn btn-sm btn-block btn-default');
-            $('.selector-chooseall').addClass('btn btn-default btn-sm');
-            $('.selector-clearall').addClass('btn btn-default btn-sm');
+            $('#channel_form .selector').addClass('row');
+            $('#channel_form .selector-available').addClass('col-sm-5');
+            $('#channel_form .selector-chosen').addClass('col-sm-5');
+            $('#channel_form .selector-chooser').addClass('col-sm-2');
+            $('#channel_form .selector-chooser > li > a').addClass('btn btn-sm btn-block btn-default');
+            $('#channel_form .selector-chooseall').addClass('btn btn-default btn-sm');
+            $('#channel_form .selector-clearall').addClass('btn btn-default btn-sm');
             $('#id_users_add_all_link').append(' <i class="fa fa-arrow-right"></i>');
             $('#id_users_remove_all_link').prepend('<i class="fa fa-arrow-left"></i> ');
             $('#id_users_add_link').append(' <i class="fa fa-arrow-right"></i>');

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -27,20 +27,23 @@ voir http://www.gnu.org/licenses/
 {% block bootstrap3_title %}{% trans "Edition of the channel" %} {{form.instance.title}}{% endblock %}
 {% block bootstrap3_extra_head %}
 
-    <!-- Admin-like selector (channel users) -->
+    <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.js"></script>
+    <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
+
+{% if user.is_staff %}
+     <!-- Admin-like selector (channel users) -->
     <style>
         .selector h2 {
             background: white url({{ STATIC_URL }}admin/img/nav-bg.gif) bottom left repeat-x;
         }
     </style>
-    <script type="text/javascript">window.__admin_media_prefix__ = "/static/admin/";</script>
+    <!--script type="text/javascript">window.__admin_media_prefix__ = "/static/admin/";</script-->
     <script type="text/javascript" src="/admin/jsi18n/"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>
-    <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.js"></script>
-    <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}admin/js/SelectBox.js"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}admin/js/SelectFilter2.js"></script>
     <!-- /Admin-like selector -->
+{% endif %}
 
     <!-- media -->
     <!-- form.media -->
@@ -185,6 +188,7 @@ voir http://www.gnu.org/licenses/
     </div>
     {% endbuttons %}
 
+    {% if user.is_staff %}
     <script type="text/javascript">
         $(document).ready(function() {
             SelectFilter.init("id_users", "{% trans 'Utilisateurs' %}", 0, "{{ STATIC_URL }}admin/");
@@ -201,6 +205,7 @@ voir http://www.gnu.org/licenses/
             $('#id_users_remove_link').prepend('<i class="fa fa-arrow-left"></i> ');
         } );
     </script>
+    {% endif %}
 
 </form>
     {% endblock article_content %}

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -176,7 +176,7 @@ voir http://www.gnu.org/licenses/
     {% if user.is_staff %}
     <script type="text/javascript">
         $(document).ready(function() {
-            SelectFilter.init("id_users", "{% trans 'Utilisateurs' %}", 0, "{{ STATIC_URL }}admin/");
+            SelectFilter.init("id_users", "{% trans 'Users' %}", 0, "{{ STATIC_URL }}admin/");
             $('#channel_form .selector').addClass('row');
             $('#channel_form .selector-available').addClass('col-sm-5');
             $('#channel_form .selector-chosen').addClass('col-sm-5');

--- a/pod_project/pods/templates/channels/channels_list.html
+++ b/pod_project/pods/templates/channels/channels_list.html
@@ -25,17 +25,14 @@ voir http://www.gnu.org/licenses/
 {% for channel in channels %}
 	<div class="video-thumb col-xs-6 col-md-4">
 	    <a href="{% url "channel" slug_c=channel.slug %}" title="{{channel.title}} ({{channel.video_count}})">
-		<span class="poster">
-			{% if channel.headband %}
-                <span class="play text-center">
-    				<span class="glyphicon glyphicon-play-circle"></span>
-    			</span>
-                <img alt="img" src="{% thumbnail channel.headband 285x160 crop upscale subject_location=channel.headband.subject_location %}" alt="{{channel.title}}" class="preview">
-            {%else%}
-                <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{channel.title}}">
-            {% endif %}
-		</span>
-		<h5>{{channel.title|safe|striptags|truncatechars:32}} ({{channel.video_count}})</h5>
+    		<span class="poster">
+    			{% if channel.headband %}
+                    <img alt="img" src="{% thumbnail channel.headband 285x160 crop upscale subject_location=channel.headband.subject_location %}" alt="{{channel.title}}" class="preview">
+                {%else%}
+                    <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{channel.title}}">
+                {% endif %}
+    		</span>
+    		<h5>{{channel.title|safe|striptags|truncatechars:32}} ({{channel.video_count}})</h5>
 		</a>
 		{% if user.is_authenticated and request.user in channel.owners.all%}
 		<span class="user-tools hidden-xs"><!-- ONLY VISIBLE TO THE VIDEO OWNER ! -->

--- a/pod_project/pods/templates/channels/channels_list.html
+++ b/pod_project/pods/templates/channels/channels_list.html
@@ -5,7 +5,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -37,8 +37,8 @@ voir http://www.gnu.org/licenses/
 		</span>
 		<h5>{{channel.title|safe|striptags|truncatechars:32}} ({{channel.video_count}})</h5>
 		</a>
-		{% if user.is_authenticated and channel.owner = request.user%}
-		<span class="user-tools hidden-xs"><!-- ONLY VISIBLE TO THE VIDEO OWNER ! --> 
+		{% if user.is_authenticated and request.user in channel.owners.all%}
+		<span class="user-tools hidden-xs"><!-- ONLY VISIBLE TO THE VIDEO OWNER ! -->
 			<a href="{% url "channel_edit" slug_c=channel.slug %}" class="btn btn-default btn-xs" title="{% trans "edit"%}"><span class="glyphicon glyphicon-pencil"></span><span class="sr-only">{% trans "edit"%}</span></a>
 	    </span>
 	    {% endif %}

--- a/pod_project/pods/tests/tests_delete_video.py
+++ b/pod_project/pods/tests/tests_delete_video.py
@@ -64,7 +64,7 @@ class Video_deleteTestView(TestCase):
         user2.set_password('hello')
         user2.save()
         c = Channel.objects.create(title="ChannelTest1", visible=True,
-                                   color="Black", owner=user, style="italic", description="blabla")
+                                   color="Black", style="italic", description="blabla")
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)

--- a/pod_project/pods/tests/tests_models.py
+++ b/pod_project/pods/tests/tests_models.py
@@ -39,7 +39,7 @@ import os
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -51,10 +51,9 @@ class ChannelTestCase(TestCase):
     fixtures = ['initial_data.json', ]
 
     def setUp(self):
-        remi = User.objects.create_user("Remi")
-        Channel.objects.create(title="ChannelTest1", slug="blabla", owner=remi)
+        Channel.objects.create(title="ChannelTest1", slug="blabla")
         Channel.objects.create(title="ChannelTest2", visible=True,
-                               color="Black", owner=remi, style="italic", description="blabla")
+                               color="Black", style="italic", description="blabla")
 
         print (" --->  SetUp of ChannelTestCase : OK !")
     """
@@ -69,7 +68,6 @@ class ChannelTestCase(TestCase):
         self.assertEqual(channel.description, '')
         self.assertEqual(channel.headband, None)
         self.assertEqual(channel.style, None)
-        self.assertEqual(channel.owner, User.objects.get(username="Remi"))
         self.assertEqual(channel.__unicode__(), 'ChannelTest1')
         self.assertEqual(channel.video_count(), 0)
         self.assertEqual(channel.get_absolute_url(), "/" + channel.slug + "/")
@@ -89,7 +87,6 @@ class ChannelTestCase(TestCase):
         self.assertEqual(channel.description, 'blabla')
         self.assertEqual(channel.headband, None)
         self.assertEqual(channel.style, "italic")
-        self.assertEqual(channel.owner, User.objects.get(username="Remi"))
         self.assertEqual(channel.__unicode__(), 'ChannelTest2')
         self.assertEqual(channel.video_count(), 0)
         self.assertEqual(channel.get_absolute_url(), "/" + channel.slug + "/")
@@ -97,7 +94,7 @@ class ChannelTestCase(TestCase):
         print (
             "   --->  test_Channel_with_attributs of ChannelTestCase : OK !")
 
-    """ 
+    """
         test delete object
     """
 
@@ -114,7 +111,7 @@ class ChannelTestCase(TestCase):
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -127,8 +124,7 @@ class ThemeTestCase(TestCase):
     fixtures = ['initial_data.json', ]
 
     def setUp(self):
-        remi = User.objects.create_user("Remi")
-        Channel.objects.create(title="ChannelTest1", owner=remi)
+        Channel.objects.create(title="ChannelTest1")
         Theme.objects.create(
             title="Theme1", slug="blabla", channel=Channel.objects.get(title="ChannelTest1"))
 
@@ -178,7 +174,7 @@ class ThemeTestCase(TestCase):
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -238,7 +234,7 @@ class TypeTestCase(TestCase):
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -298,7 +294,7 @@ class DisciplineTestCase(TestCase):
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -334,7 +330,7 @@ class NextAutoIncrementTestCase(TestCase):
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -467,7 +463,7 @@ class VideoTestCase(TestCase):
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -518,7 +514,7 @@ class FavoritesTestCase(TestCase):
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -576,7 +572,7 @@ class NotesTestCase(TestCase):
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -641,7 +637,7 @@ class MediaCoursesTestCase(TestCase):
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -679,12 +675,12 @@ class BuildingTestCase(TestCase):
         print (
             "   --->  test_delete_object of BuildingTestCase : OK !")
 
-"""              
+"""
 	test recorder object
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -738,12 +734,12 @@ class RecoderTestCase(TestCase):
         print (
             "   --->  test_delete_object of RecoderTestCase : OK !")
 
-"""              
+"""
     test reportVideo object
 """
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',

--- a/pod_project/pods/tests/tests_views.py
+++ b/pod_project/pods/tests/tests_views.py
@@ -62,7 +62,7 @@ class ChannelsTestView(TestCase):
         i = 1
         while i <= 15:
             Channel.objects.create(title="ChannelTest" + str(i), visible=True,
-                                   color="Black", owner=remi, style="italic", description="blabla")
+                                   color="Black", style="italic", description="blabla")
             i += 1
 
         t = Theme.objects.create(
@@ -147,8 +147,9 @@ class Owner_channels_listTestView(TestCase):
 
         i = 1
         while i <= 5:
-            Channel.objects.create(title="ChannelTest" + str(i), visible=True,
-                                   color="Black", owner=remi, style="italic", description="blabla")
+            c = Channel.objects.create(title="ChannelTest" + str(i), visible=True,
+                                   color="Black", style="italic", description="blabla")
+            c.owners.add(remi)
             i += 1
         print(" --->  SetUp of Owner_channels_listTestView : OK !")
 
@@ -157,7 +158,7 @@ class Owner_channels_listTestView(TestCase):
         self.user = User.objects.get(username="testuser")
         self.user = authenticate(username='testuser', password='hello')
         login = self.client.login(username='testuser', password='hello')
-        channels = list(Channel.objects.filter(owner=self.user))
+        channels = list(Channel.objects.filter(owners=self.user))
         self.assertEqual(login, True)
         response = self.client.get("/owner_channels_list/")
         self.assertEqual(response.status_code, 200)
@@ -198,7 +199,7 @@ class ChannelTestView(TestCase):
     def setUp(self):
         remi = User.objects.create(username='testuser')
         c = Channel.objects.create(title="ChannelTest1", visible=True,
-                                   color="Black", owner=remi, style="italic", description="blabla")
+                                   color="Black", style="italic", description="blabla")
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
@@ -271,8 +272,9 @@ class Channel_edit_TestView(TestCase):
             username='testuser2', password='12345', is_active=True, is_staff=True, is_superuser=False)
         user2.set_password('hello')
         user2.save()
-        Channel.objects.create(title="ChannelTest1", visible=True,
-                               color="Black", owner=self.user, style="italic", description="blabla")
+        c = Channel.objects.create(title="ChannelTest1", visible=True,
+                               color="Black", style="italic", description="blabla")
+        c.owners.add(self.user)
         print(" --->  SetUp of Channel_edit_TestView : OK !")
 
     def test_channel_edit_get_request(self):
@@ -911,7 +913,7 @@ class VideoTestView(TestCase):
         user2.set_password('hello')
         user2.save()
         c = Channel.objects.create(title="ChannelTest1", visible=True,
-                                   color="Black", owner=user, style="italic", description="blabla")
+                                   color="Black", style="italic", description="blabla")
         t = Theme.objects.create(
             title="Theme1", channel=c)
         type1 = Type.objects.create(title="type1")
@@ -1028,7 +1030,7 @@ class Video_edit_testCase(TestCase):
         user2.set_password('hello')
         user2.save()
         c = Channel.objects.create(title="ChannelTest1", visible=True,
-                                   color="Black", owner=user, style="italic", description="blabla")
+                                   color="Black", style="italic", description="blabla")
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
@@ -1129,7 +1131,7 @@ class Video_notesTestView(TestCase):
         user2.set_password('hello')
         user2.save()
         c = Channel.objects.create(title="ChannelTest1", visible=True,
-                                   color="Black", owner=user, style="italic", description="blabla")
+                                   color="Black", style="italic", description="blabla")
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
@@ -1204,7 +1206,7 @@ class Video_completion_TestView(TestCase):
         userNoStaff.set_password('hello')
         userNoStaff.save()
         c = Channel.objects.create(title="ChannelTest1", visible=True,
-                                   color="Black", owner=user, style="italic", description="blabla")
+                                   color="Black", style="italic", description="blabla")
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
@@ -1532,7 +1534,7 @@ class Video_chapterTestView(TestCase):
         user2.set_password('hello')
         user2.save()
         c = Channel.objects.create(title="ChannelTest1", visible=True,
-                                   color="Black", owner=user, style="italic", description="blabla")
+                                   color="Black", style="italic", description="blabla")
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
@@ -1800,7 +1802,7 @@ class Video_enrichTestView(TestCase):
         user2.set_password('hello')
         user2.save()
         c = Channel.objects.create(title="ChannelTest1", visible=True,
-                                   color="Black", owner=user, style="italic", description="blabla")
+                                   color="Black", style="italic", description="blabla")
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -167,12 +167,13 @@ def channel_edit(request, slug_c):
     ThemeInlineFormSet = inlineformset_factory(
         Channel, Theme, form=ThemeForm, extra=0)
 
-    channel_form = ChannelForm(instance=channel)
+    channel_form = ChannelForm(instance=channel, user=request.user)
     #formset = ThemeInlineFormSet(instance=channel)
     referer = request.META.get('HTTP_REFERER')
 
     if request.POST:
-        channel_form = ChannelForm(request.POST, instance=channel)
+        channel_form = ChannelForm(
+            request.POST, instance=channel, user=request.user)
         formset = ThemeInlineFormSet(request.POST, instance=channel)
         if channel_form.is_valid() and formset.is_valid():
             channel = channel_form.save()

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -164,8 +164,12 @@ def channel_edit(request, slug_c):
             request, messages.ERROR, _(u'You cannot edit this channel.'))
         raise PermissionDenied
 
-    ThemeInlineFormSet = inlineformset_factory(
-        Channel, Theme, form=ThemeForm, extra=0)
+    if request.user.is_staff:
+        ThemeInlineFormSet = inlineformset_factory(
+            Channel, Theme, form=ThemeForm, extra=0)
+    else:
+        ThemeInlineFormSet = inlineformset_factory(
+            Channel, Theme, form=ThemeForm, exclude=('headband',), extra=0)
 
     channel_form = ChannelForm(instance=channel, user=request.user)
     #formset = ThemeInlineFormSet(instance=channel)

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -159,7 +159,7 @@ def channel_edit(request, slug_c):
         request.session['filer_last_folder_id'] = folder.id
 
     channel = get_object_or_404(Channel, slug=slug_c)
-    if request.user != channel.owner and not request.user.is_superuser:
+    if request.user not in channel.owners.all() and not request.user.is_superuser:
         messages.add_message(
             request, messages.ERROR, _(u'You cannot edit this channel.'))
         raise PermissionDenied

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -74,7 +74,7 @@ def get_pagination(page, paginator):
 
 @login_required
 def owner_channels_list(request):
-    channels_list = request.user.owner_channels.all()
+    channels_list = request.user.owners_channels.all()
     per_page = request.COOKIES.get('perpage') if request.COOKIES.get(
         'perpage') and request.COOKIES.get('perpage').isdigit() else DEFAULT_PER_PAGE
     paginator = Paginator(channels_list, per_page)

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-02 17:03+0200\n"
-"PO-Revision-Date: 2016-09-15 11:19+0200\n"
+"POT-Creation-Date: 2016-09-15 17:43+0200\n"
+"PO-Revision-Date: 2016-09-15 18:12+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -46,7 +46,7 @@ msgstr ""
 "Ce champ vous permet d'ajouter une photo d'identité. L'image sera affichée "
 "avec vos vidéos."
 
-#: core/models.py:91 core/models.py:172 pods/models.py:64
+#: core/models.py:91 core/models.py:172 pods/models.py:65
 msgid "Description"
 msgstr "Description"
 
@@ -58,7 +58,7 @@ msgstr ""
 "Ce champ vous permet d'écrire quelques mots sur vous-même. Le texte sera "
 "affiché avec vos vidéos."
 
-#: core/models.py:93 pods/models.py:523 pods/models.py:712
+#: core/models.py:93 pods/models.py:537 pods/models.py:728
 #: pods/templates/videos/completion/contributor/list_contributor.html:35
 msgid "Web link"
 msgstr "Lien web"
@@ -67,7 +67,7 @@ msgstr "Lien web"
 msgid "This field allows you to add an url."
 msgstr "Ce champ vous permet d'ajouter une adresse web."
 
-#: core/models.py:98 pods/models.py:1027
+#: core/models.py:98 pods/models.py:1055
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -79,8 +79,8 @@ msgstr "Profil"
 msgid "Profiles"
 msgstr "Profils"
 
-#: core/models.py:151 pods/models.py:315 pods/models.py:466 pods/models.py:636
-#: pods/models.py:1024
+#: core/models.py:151 pods/models.py:329 pods/models.py:480 pods/models.py:650
+#: pods/models.py:1052
 msgid "Video"
 msgstr "Vidéo"
 
@@ -88,18 +88,18 @@ msgstr "Vidéo"
 msgid "allow downloading"
 msgstr "Autoriser le téléchargement"
 
-#: core/models.py:154 pods/models.py:59 pods/models.py:109 pods/models.py:148
+#: core/models.py:154 pods/models.py:59 pods/models.py:110 pods/models.py:151
 #: pods/templates/videos/chapter/list_chapter.html:31
 #: pods/templates/videos/enrich/list_enrich.html:32
 msgid "Title"
 msgstr "Titre"
 
-#: core/models.py:155 pods/models.py:60 pods/models.py:110 pods/models.py:149
+#: core/models.py:155 pods/models.py:61 pods/models.py:112 pods/models.py:153
 msgid "Slug"
 msgstr "Titre web"
 
-#: core/models.py:157 pods/models.py:61 pods/models.py:111 pods/models.py:150
-#: pods/models.py:184 pods/models.py:687 pods/models.py:837
+#: core/models.py:157 pods/models.py:63 pods/models.py:114 pods/models.py:155
+#: pods/models.py:191 pods/models.py:702 pods/models.py:858
 msgid ""
 "Used to access this instance, the \"slug\" is a short label containing only "
 "letters, numbers, underscore or dash top."
@@ -110,7 +110,7 @@ msgstr ""
 
 #: core/models.py:159 core/templates/admin/filer/folder/directory_table.html:14
 #: core/templates/admin/filer/folder/directory_table.html:33
-#: core/templates/admin/filer/folder/directory_table.html:81 pods/models.py:73
+#: core/templates/admin/filer/folder/directory_table.html:81
 #: pods/templates/search/search_video.html:163
 msgid "Owner"
 msgstr "Propriétaire"
@@ -155,12 +155,12 @@ msgstr "Vue d'ensemble"
 msgid "Duration"
 msgstr "Durée"
 
-#: core/models.py:197 core/models.py:198 pods/models.py:504 pods/models.py:576
-#: pods/models.py:683 pods/models.py:833
+#: core/models.py:197 core/models.py:198 pods/models.py:518 pods/models.py:590
+#: pods/models.py:697 pods/models.py:853
 msgid "video"
 msgstr "video"
 
-#: core/models.py:234 pods/models.py:978 pods/models.py:995
+#: core/models.py:234 pods/models.py:999 pods/models.py:1017
 msgid "name"
 msgstr "nom"
 
@@ -276,10 +276,9 @@ msgstr "Taille"
 #: core/templates/admin/filer/folder/directory_table.html:24
 #: core/templates/admin/filer/folder/directory_table.html:27
 #: core/templates/admin/filer/folder/directory_table.html:37
-#, fuzzy, python-format
-#| msgid "Change '%(item_label)s' folder details."
+#, python-format
 msgid "Change '%(item_label)s' folder details"
-msgstr "Modifier les informations du dossier '%(item_label)s'."
+msgstr "Modifier les informations du dossier '%(item_label)s'"
 
 #: core/templates/admin/filer/folder/directory_table.html:24
 msgid "Folder Icon"
@@ -312,10 +311,9 @@ msgstr "Sélectionner ce fichier"
 
 #: core/templates/admin/filer/folder/directory_table.html:47
 #: core/templates/admin/filer/folder/directory_table.html:85
-#, fuzzy, python-format
-#| msgid "Change '%(item_label)s' details."
+#, python-format
 msgid "Change '%(item_label)s' details"
-msgstr "Modifier les informations de '%(item_label)s'."
+msgstr "Modifier les informations de '%(item_label)s'"
 
 #: core/templates/admin/filer/folder/directory_table.html:54
 #: core/templates/admin/filer/folder/directory_table.html:69
@@ -336,14 +334,11 @@ msgid "enabled"
 msgstr "activé"
 
 #: core/templates/admin/filer/folder/directory_table.html:86
-#, fuzzy, python-format
-#| msgid "Delete '%(item_label)s'."
+#, python-format
 msgid "Delete '%(item_label)s'"
-msgstr "Supprimer '%(item_label)s'."
+msgstr "Supprimer '%(item_label)s'"
 
 #: core/templates/admin/filer/folder/directory_table.html:86
-#: pods/templates/channels/channel_edit.html:129
-#: pods/templates/channels/channel_edit.html:156
 #: pods/templates/videos/chapter/list_chapter.html:55
 #: pods/templates/videos/enrich/list_enrich.html:60
 #: pods/templates/videos/ownertools.html:45
@@ -354,8 +349,6 @@ msgid "Delete"
 msgstr "Supprimer"
 
 #: core/templates/admin/filer/folder/directory_table.html:88
-#, fuzzy
-#| msgid "Move to clipboard."
 msgid "Move to clipboard"
 msgstr "Déplacer vers le presse-papier."
 
@@ -395,9 +388,8 @@ msgid "Full size preview"
 msgstr "Aperçu en taille maximale"
 
 #: core/templates/admin/filer/tools/clipboard/clipboard.html:8
-#, fuzzy
-#| msgid "Empty Clipboard"
-msgid "Clipboard"
+#: core/templates/admin/filer/tools/clipboard/clipboard.html:27
+msgid "Empty Clipboard"
 msgstr "Vider"
 
 #: core/templates/admin/filer/tools/clipboard/clipboard.html:20
@@ -409,26 +401,17 @@ msgid "Paste"
 msgstr "Coller"
 
 #: core/templates/admin/filer/tools/clipboard/clipboard.html:27
-#, fuzzy
-#| msgid "Move to clipboard."
 msgid "Move all clipboard files to"
-msgstr "Déplacer vers le presse-papier."
+msgstr "Déplacer tous les fichiers du presse-papier vers"
 
 #: core/templates/admin/filer/tools/clipboard/clipboard.html:27
 #, fuzzy
-#| msgid "upload files"
 msgid "unfiled files"
-msgstr "Téléverser des fichiers"
+msgstr "fichiers vacants"
 
 #: core/templates/admin/filer/tools/clipboard/clipboard.html:27
-#, fuzzy
-#| msgid "Folder"
 msgid "folder"
-msgstr "Dossier"
-
-#: core/templates/admin/filer/tools/clipboard/clipboard.html:27
-msgid "Empty Clipboard"
-msgstr "Vider"
+msgstr "dossier"
 
 #: core/templates/admin/filer/tools/clipboard/clipboard.html:44
 msgid "the clipboard is empty"
@@ -436,16 +419,12 @@ msgstr "le presse-papiers est vide"
 
 #: core/templates/admin/filer/widgets/admin_file.html:8
 #: core/templates/admin/filer/widgets/admin_file.html:9
-#, fuzzy
-#| msgid "File missing"
 msgid "file missing"
-msgstr "Fichier manquant"
+msgstr "fichier manquant"
 
 #: core/templates/admin/filer/widgets/admin_file.html:12
-#, fuzzy
-#| msgid "No file selected"
 msgid "no file selected"
-msgstr "Aucun fichier sélectionné"
+msgstr "aucun fichier sélectionné"
 
 #: core/templates/admin/filer/widgets/admin_file.html:16
 msgid "Clear"
@@ -471,7 +450,7 @@ msgid "Share"
 msgstr "Partager"
 
 #: core/templates/base.html:157 core/templates/base.html.py:164
-#: pods/models.py:202 pods/models.py:299
+#: pods/models.py:209 pods/models.py:304
 #: pods/templates/disciplines/disciplines.html:24
 #: pods/templates/disciplines/disciplines.html:31
 #: pods/templates/disciplines/disciplines.html:39
@@ -485,7 +464,7 @@ msgstr "Disciplines"
 msgid "See all"
 msgstr "Afficher tout"
 
-#: core/templates/base.html:177 pods/models.py:295
+#: core/templates/base.html:177 pods/models.py:301
 #: pods/templates/search/search_video.html:187 pods/templates/tags/tags.html:25
 #: pods/templates/tags/tags.html.py:86 pods/templates/tags/tags.html:96
 #: pods/templates/tags/tags.html.py:104 pods/templates/videos/video.html:296
@@ -497,14 +476,12 @@ msgstr "Mots clés"
 msgid "See the cloud"
 msgstr "Voir le nuage"
 
-#: core/templates/base.html:197 pods/models.py:933
+#: core/templates/base.html:197 pods/models.py:954
 msgid "Notes"
 msgstr "Notes"
 
-#: core/templates/base.html:205 pods/templates/channels/channel_edit.html:91
-#: pods/templates/channels/channel_edit.html:92
-#: pods/templates/channels/channel_edit.html:172
-#: pods/templates/channels/channel_edit.html:173
+#: core/templates/base.html:205 pods/templates/channels/channel_edit.html:164
+#: pods/templates/channels/channel_edit.html:165
 #: pods/templates/pagination.html:41
 #: pods/templates/videos/chapter/form_chapter.html:43
 #: pods/templates/videos/enrich/form_enrich.html:43
@@ -572,12 +549,12 @@ msgstr "Envoyer"
 
 #: core/templates/contactus/contactus.html:26
 #: core/templates/userProfile.html:64 core/views.py:166
-#: pods/templates/channels/channel_edit.html:77
+#: pods/templates/channels/channel_edit.html:84
 #: pods/templates/mediacourses/mediacourses_add.html:52
 #: pods/templates/videos/video_chapter.html:258
 #: pods/templates/videos/video_edit.html:325
-#: pods/templates/videos/video_enrich.html:255 pods/views.py:191
-#: pods/views.py:456 pods/views.py:703 pods/views.py:707 pods/views.py:1648
+#: pods/templates/videos/video_enrich.html:255 pods/views.py:196
+#: pods/views.py:461 pods/views.py:708 pods/views.py:712 pods/views.py:1653
 msgid "One or more errors have been found in the form."
 msgstr "Une ou plusieurs erreurs ont été trouvées dans le formulaire."
 
@@ -596,7 +573,7 @@ msgstr "Retour"
 msgid "Here are the latest videos"
 msgstr "Voici les dernières vidéos"
 
-#: core/templates/header.html:41 pods/models.py:586
+#: core/templates/header.html:41 pods/models.py:600
 #: pods/templates/videos/completion/subtitle/list_subtitle.html:34
 msgid "Language"
 msgstr "Langue"
@@ -632,7 +609,7 @@ msgid "Log in"
 msgstr "Connexion"
 
 #: core/templates/navbar.html:45 core/templates/navbar.html.py:67
-#: pods/models.py:85 pods/models.py:301 pods/templates/channels/channel.html:49
+#: pods/models.py:86 pods/models.py:306 pods/templates/channels/channel.html:49
 #: pods/templates/channels/channels.html:24
 #: pods/templates/channels/channels.html:31
 #: pods/templates/channels/channels.html:39
@@ -647,13 +624,13 @@ msgid "Authors"
 msgstr "Auteurs"
 
 #: core/templates/navbar.html:99 core/templates/navbar.html.py:109
-#: pods/models.py:168 pods/templates/types/types.html:24
+#: pods/models.py:173 pods/templates/types/types.html:24
 #: pods/templates/types/types.html.py:28 pods/templates/types/types.html:33
 #: pods/templates/types/types.html.py:41 pods/templates/videos/videos.html:82
 msgid "Types"
 msgstr "Types"
 
-#: core/templates/navbar.html:115 pods/models.py:316
+#: core/templates/navbar.html:115 pods/models.py:330
 #: pods/templates/videos/video.html:153 pods/templates/videos/videos.html:26
 #: pods/templates/videos/videos.html:30 pods/templates/videos/videos.html:32
 msgid "Videos"
@@ -666,7 +643,7 @@ msgid "Add a new video"
 msgstr "Ajouter une nouvelle vidéo"
 
 #: core/templates/navbar.html:123 core/templates/navbar.html.py:127
-#: pods/forms.py:302 pods/templates/search/search_video.html:25
+#: pods/forms.py:322 pods/templates/search/search_video.html:25
 #: pods/templates/search/search_video.html:55
 #: pods/templates/search/search_video.html:65
 #: pods/templates/search/search_video.html:153
@@ -705,12 +682,12 @@ msgid "Contact us"
 msgstr "Contactez nous"
 
 #: core/templates/userProfile.html:24
-#: pods/templates/channels/channel_edit.html:64
+#: pods/templates/channels/channel_edit.html:71
 msgid "My profile"
 msgstr "Mon profil"
 
 #: core/templates/userProfile.html:39
-#: pods/templates/channels/channel_edit.html:47
+#: pods/templates/channels/channel_edit.html:56
 #: pods/templates/mediacourses/mediacourses_add.html:31
 #: pods/templates/videos/video_chapter.html:131
 #: pods/templates/videos/video_completion.html:175
@@ -751,7 +728,7 @@ msgstr "Foire aux questions"
 msgid "Login"
 msgstr "Identifiant"
 
-#: core/views.py:95 pods/admin.py:98 pods/forms.py:288
+#: core/views.py:95 pods/admin.py:121 pods/forms.py:308
 #: pods/templates/videos/video_edit.html:448
 msgid "Password"
 msgstr "Mot de passe"
@@ -1448,30 +1425,36 @@ msgstr "Autre"
 msgid "Français"
 msgstr "Français"
 
-#: pods/admin.py:106
+#: pods/admin.py:54 pods/models.py:72 pods/templates/owners/owners.html:24
+#: pods/templates/owners/owners.html:31 pods/templates/owners/owners.html:39
+#: pods/templates/owners/owners.html:41
+msgid "Owners"
+msgstr "Propriétaires"
+
+#: pods/admin.py:129
 msgid "Encode selected"
 msgstr "(Ré)encoder la sélection"
 
-#: pods/forms.py:127
+#: pods/forms.py:147
 msgid "Filetype not allowed! Filetypes allowed: "
 msgstr "Type de fichier non admis ! Les types de fichiers acceptés sont : "
 
-#: pods/forms.py:133
+#: pods/forms.py:153
 msgid "Date of the event"
 msgstr "Date de l'évènement"
 
-#: pods/forms.py:135
+#: pods/forms.py:155
 msgid "File"
 msgstr "Fichier"
 
-#: pods/models.py:66 pods/models.py:114 pods/models.py:153 pods/models.py:187
+#: pods/models.py:67 pods/models.py:117 pods/models.py:158 pods/models.py:194
 #: pods/templates/channels/channel.html:109
 #: pods/templates/channels/channel.html:145
 #: pods/templates/channels/channel.html:158
 msgid "Headband"
 msgstr "Bandeau"
 
-#: pods/models.py:68
+#: pods/models.py:69
 msgid "Background color"
 msgstr "Couleur de fond"
 
@@ -1479,15 +1462,15 @@ msgstr "Couleur de fond"
 msgid "Extra style"
 msgstr "Style supplémentaire"
 
-#: pods/models.py:75
+#: pods/models.py:75 pods/templates/channels/channel_edit.html:179
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: pods/models.py:77
+#: pods/models.py:78
 msgid "Visible"
 msgstr "Visible"
 
-#: pods/models.py:79
+#: pods/models.py:80
 msgid ""
 "If checked, the channel appear in a list of available channels on the "
 "platform."
@@ -1495,46 +1478,46 @@ msgstr ""
 "Si cochée, la chaîne apparait dans la liste des chaînes disponibles sur la "
 "plate-forme."
 
-#: pods/models.py:84 pods/models.py:116
+#: pods/models.py:85 pods/models.py:119
 #: pods/templates/search/search_video.html:212
 msgid "Channel"
 msgstr "Chaîne"
 
-#: pods/models.py:104 pods/models.py:143 pods/models.py:177 pods/models.py:211
+#: pods/models.py:105 pods/models.py:146 pods/models.py:182 pods/models.py:218
 msgid "count"
 msgstr "compte"
 
-#: pods/models.py:130
+#: pods/models.py:133
 msgid "Theme"
 msgstr "Thème"
 
-#: pods/models.py:131 pods/models.py:303
+#: pods/models.py:134 pods/models.py:308
 #: pods/templates/channels/channel.html:120
-#: pods/templates/channels/channel_edit.html:105
+#: pods/templates/channels/channel_edit.html:97
 msgid "Themes"
 msgstr "Thèmes"
 
-#: pods/models.py:167 pods/models.py:297 pods/models.py:706
+#: pods/models.py:172 pods/models.py:302 pods/models.py:722
 #: pods/templates/search/search_video.html:175
 #: pods/templates/videos/enrich/list_enrich.html:33
 #: pods/templates/videos/video.html:328
 msgid "Type"
 msgstr "Type"
 
-#: pods/models.py:182 pods/models.py:684 pods/models.py:834 pods/models.py:947
+#: pods/models.py:187 pods/models.py:698 pods/models.py:854 pods/models.py:968
 msgid "title"
 msgstr "titre"
 
-#: pods/models.py:183 pods/models.py:685 pods/models.py:835
+#: pods/models.py:189 pods/models.py:700 pods/models.py:856
 msgid "slug"
 msgstr "titre court"
 
-#: pods/models.py:201 pods/templates/search/search_video.html:199
+#: pods/models.py:208 pods/templates/search/search_video.html:199
 #: pods/templates/videos/video.html:335
 msgid "Discipline"
 msgstr "Discipline"
 
-#: pods/models.py:294
+#: pods/models.py:300
 msgid ""
 "Separate tags with spaces, enclose the tags consist of several words in "
 "quotation marks."
@@ -1542,23 +1525,23 @@ msgstr ""
 "Séparez les mots-clés avec des espaces, placez les mots-clés constitués de "
 "plusieurs mots entre guillemets."
 
-#: pods/models.py:307 pods/templates/videos/video_edit.html:430
+#: pods/models.py:313 pods/templates/videos/video_edit.html:430
 msgid "Draft"
 msgstr "Brouillon"
 
-#: pods/models.py:308
+#: pods/models.py:315
 msgid ""
 "If this box is checked, the video will be visible and accessible only by you."
 msgstr ""
 "Si cette case est cochée, la vidéo sera visible et accessible uniquement par "
 "vous."
 
-#: pods/models.py:309 pods/models.py:1004
+#: pods/models.py:318 pods/models.py:1029
 #: pods/templates/videos/video_edit.html:438
 msgid "Restricted access"
 msgstr "Accès restreint"
 
-#: pods/models.py:310
+#: pods/models.py:320
 msgid ""
 "If this box is checked, the video will only be accessible to authenticated "
 "users."
@@ -1566,381 +1549,381 @@ msgstr ""
 "Si cette case est cochée, la vidéo sera accessible uniquement par les "
 "utilisateurs authentifiés."
 
-#: pods/models.py:311
+#: pods/models.py:323
 msgid "password"
 msgstr "Mot de passe"
 
-#: pods/models.py:312
+#: pods/models.py:325
 msgid "Viewing this video will not be possible without this password."
 msgstr ""
 "Le visionnage de la vidéo ne pourra se faire qu'après avoir fourni ce mot de "
 "passe."
 
-#: pods/models.py:468
+#: pods/models.py:482
 msgid "encodingType"
 msgstr "type d'encodage"
 
-#: pods/models.py:470
+#: pods/models.py:484
 msgid "encodingFile"
 msgstr "Fichier résultant"
 
-#: pods/models.py:478
+#: pods/models.py:492
 msgid "Format"
 msgstr "format"
 
-#: pods/models.py:486
+#: pods/models.py:500
 msgid "encoding"
 msgstr "encodage"
 
-#: pods/models.py:487
+#: pods/models.py:501
 msgid "encodings"
 msgstr "encodages"
 
-#: pods/models.py:505
+#: pods/models.py:519
 msgid "lastname / firstname"
 msgstr "Nom / Prénom"
 
-#: pods/models.py:507
+#: pods/models.py:521
 msgid "mail"
 msgstr "courriel"
 
-#: pods/models.py:509
+#: pods/models.py:523
 msgid "author"
 msgstr "auteur"
 
-#: pods/models.py:510
+#: pods/models.py:524
 msgid "director"
 msgstr "directeur"
 
-#: pods/models.py:511
+#: pods/models.py:525
 msgid "editor"
 msgstr "éditeur"
 
-#: pods/models.py:512
+#: pods/models.py:526
 msgid "designer"
 msgstr "concepteur"
 
-#: pods/models.py:513
+#: pods/models.py:527
 msgid "contributor"
 msgstr "contributeur"
 
-#: pods/models.py:514
+#: pods/models.py:528
 msgid "actor"
 msgstr "acteur"
 
-#: pods/models.py:515
+#: pods/models.py:529
 msgid "voice-over"
 msgstr "voix-off"
 
-#: pods/models.py:516
+#: pods/models.py:530
 msgid "consultant"
 msgstr "consultant"
 
-#: pods/models.py:517
+#: pods/models.py:531
 msgid "writer"
 msgstr "écrivain"
 
-#: pods/models.py:518
+#: pods/models.py:532
 msgid "soundman"
 msgstr "preneur de son"
 
-#: pods/models.py:519
+#: pods/models.py:533
 msgid "technician"
 msgstr "technicien"
 
-#: pods/models.py:521
+#: pods/models.py:535
 msgid "role"
 msgstr "rôle"
 
-#: pods/models.py:521
+#: pods/models.py:535
 msgid "authors"
 msgstr "auteurs"
 
-#: pods/models.py:526
+#: pods/models.py:540
 msgid "Contributor Pod"
 msgstr "Contributeur"
 
-#: pods/models.py:527
+#: pods/models.py:541
 msgid "Contributors Pod"
 msgstr "Contributeurs"
 
-#: pods/models.py:539
+#: pods/models.py:553
 msgid "please enter a name from 2 to 200 caracteres."
 msgstr "Veuillez renseigner un titre contenant entre 2 et 100 caractères. "
 
-#: pods/models.py:541
+#: pods/models.py:555
 msgid "you cannot enter a weblink with more than 200 caracteres."
 msgstr "les liens internet doivent être inférieur à 200 caractères. "
 
-#: pods/models.py:543
+#: pods/models.py:557
 msgid "please enter a role."
 msgstr "Veuillez renseigner un rôle."
 
-#: pods/models.py:557
+#: pods/models.py:571
 msgid "there is already a contributor with the same name and role in the list."
 msgstr "Un contributeur avec le même nom et le même role existe déjà."
 
-#: pods/models.py:579
+#: pods/models.py:593
 msgid "subtitles"
 msgstr "sous-titres"
 
-#: pods/models.py:580
+#: pods/models.py:594
 msgid "captions"
 msgstr "légendes"
 
-#: pods/models.py:583
+#: pods/models.py:597
 #: pods/templates/videos/completion/subtitle/list_subtitle.html:33
 msgid "Kind"
 msgstr "Genre"
 
-#: pods/models.py:588
+#: pods/models.py:602
 msgid "subtitle file"
 msgstr "fichier de sous-titres"
 
-#: pods/models.py:591
+#: pods/models.py:605
 msgid "Track Pod"
 msgstr "Piste"
 
-#: pods/models.py:592
+#: pods/models.py:606
 msgid "Tracks Pod"
 msgstr "Pistes"
 
-#: pods/models.py:604
+#: pods/models.py:618
 msgid "please enter a correct kind."
 msgstr "Veuillez renseigner le type de piste."
 
-#: pods/models.py:606
+#: pods/models.py:620
 msgid "please enter a correct lang."
 msgstr "Veuillez renseigner une langue."
 
-#: pods/models.py:608
+#: pods/models.py:622
 msgid "please specify a track file."
 msgstr "Veuillez spécifier un fichier de sous-titre ou de légende."
 
-#: pods/models.py:622
+#: pods/models.py:636
 msgid ""
 "there is already a subtitle with the same kind and language in the list."
 msgstr "Un sous-titrage de même nature et de même langue existe déjà."
 
-#: pods/models.py:640
+#: pods/models.py:654
 msgid "Document Pod"
 msgstr "Document"
 
-#: pods/models.py:641
+#: pods/models.py:655
 msgid "Documents Pod"
 msgstr "Documents"
 
-#: pods/models.py:657
+#: pods/models.py:671
 msgid "please enter a document "
 msgstr "veuillez sélectionner un document "
 
-#: pods/models.py:672
+#: pods/models.py:686
 msgid "this document is already contained in the list."
 msgstr "Ce document a déjà été envoyé."
 
-#: pods/models.py:691
+#: pods/models.py:705
 msgid "Stop video"
 msgstr "Arrêter la lecture"
 
-#: pods/models.py:692
+#: pods/models.py:706
 msgid "The video will pause when displaying this enrichment."
 msgstr "La vidéo se met en pause lors de l'affichage de cet enrichissement."
 
-#: pods/models.py:694 pods/templates/videos/enrich/list_enrich.html:34
+#: pods/models.py:708 pods/templates/videos/enrich/list_enrich.html:34
 msgid "Start"
 msgstr "Début"
 
-#: pods/models.py:694
+#: pods/models.py:709
 msgid "Start of enrichment display in seconds"
 msgstr "Début d'affichage de l'enrichissement en secondes"
 
-#: pods/models.py:696 pods/templates/videos/enrich/list_enrich.html:35
+#: pods/models.py:711 pods/templates/videos/enrich/list_enrich.html:35
 msgid "End"
 msgstr "Fin"
 
-#: pods/models.py:696
+#: pods/models.py:712
 msgid "End of enrichment display in seconds"
 msgstr "Fin d'affichage de l'enrichissement en secondes"
 
-#: pods/models.py:699
+#: pods/models.py:715
 msgid "image"
 msgstr "image"
 
-#: pods/models.py:700 pods/models.py:710
+#: pods/models.py:716 pods/models.py:726
 msgid "richtext"
 msgstr "texte enrichi et mis en forme"
 
-#: pods/models.py:701
+#: pods/models.py:717
 msgid "weblink"
 msgstr "lien web"
 
-#: pods/models.py:702
+#: pods/models.py:718
 msgid "document"
 msgstr "document"
 
-#: pods/models.py:703
+#: pods/models.py:719
 msgid "embed"
 msgstr "intégrer"
 
-#: pods/models.py:714
+#: pods/models.py:732
 msgid "Integrate an document (PDF, text, html)"
 msgstr "Afficher un document (PDF, texte ou html)"
 
-#: pods/models.py:715
+#: pods/models.py:734
 msgid "Embed"
 msgstr "Intégrer"
 
-#: pods/models.py:716
+#: pods/models.py:736
 msgid "Integrate an external source"
 msgstr "Afficher une source externe (video youtube par exemple)"
 
-#: pods/models.py:719
+#: pods/models.py:739
 msgid "Enrichment"
 msgstr "Enrichissement"
 
-#: pods/models.py:720
+#: pods/models.py:740
 msgid "Enrichments"
 msgstr "Enrichissements"
 
-#: pods/models.py:741 pods/models.py:864
+#: pods/models.py:761 pods/models.py:885
 #: pods/templates/videos/video_chapter.html:281
 #: pods/templates/videos/video_enrich.html:327
 msgid "Please enter a title from 2 to 100 characters."
 msgstr "Veuillez renseigner un titre contenant entre 2 et 100 caractères."
 
-#: pods/models.py:744 pods/models.py:867
+#: pods/models.py:764 pods/models.py:888
 #, python-format
 msgid "Please enter a correct start field between 0 and %(duration)s."
 msgstr ""
 "Veuillez renseigner une valeur de début d'enrichissement comprise entre 0 et "
 "%(duration)s."
 
-#: pods/models.py:748
+#: pods/models.py:768
 #, python-format
 msgid "Please enter a correct end field between 1 and %(duration)s."
 msgstr ""
 "Veuillez renseigner une valeur de fin d'enrichissement comprise entre 1 et "
 "%(duration)s."
 
-#: pods/models.py:752 pods/templates/videos/video_enrich.html:345
+#: pods/models.py:772 pods/templates/videos/video_enrich.html:345
 msgid "Please enter a correct image."
 msgstr "Veuillez renseigner une image."
 
-#: pods/models.py:756 pods/templates/videos/video_enrich.html:352
+#: pods/models.py:776 pods/templates/videos/video_enrich.html:352
 msgid "Please enter a correct richtext."
 msgstr "Veuillez renseigner un texte."
 
-#: pods/models.py:760 pods/templates/videos/video_enrich.html:359
+#: pods/models.py:780 pods/templates/videos/video_enrich.html:359
 msgid "Please enter a correct weblink."
 msgstr "Veuillez renseigner un lien internet."
 
-#: pods/models.py:764 pods/templates/videos/video_completion.html:410
+#: pods/models.py:784 pods/templates/videos/video_completion.html:410
 #: pods/templates/videos/video_enrich.html:372
 msgid "Please select a document."
 msgstr "Veuillez sélectionner un document."
 
-#: pods/models.py:768 pods/templates/videos/video_enrich.html:379
+#: pods/models.py:788 pods/templates/videos/video_enrich.html:379
 msgid "Please enter a correct embed."
 msgstr "Veuillez renseigner un code embed."
 
-#: pods/models.py:770 pods/templates/videos/video_enrich.html:391
+#: pods/models.py:790 pods/templates/videos/video_enrich.html:391
 msgid "Please enter a type in index field."
 msgstr "Veuillez choisir un type d'enrichissement."
 
-#: pods/models.py:783
+#: pods/models.py:803
 msgid "The value of the start field is greater than the value of end field."
 msgstr "La valeur du commencement ne peut être supérieure à celle de la fin."
 
-#: pods/models.py:786
+#: pods/models.py:806
 msgid "The value of end field is greater than the video duration."
 msgstr ""
 "La valeur de fin d'enrichissement est supérieure à la durée de la vidéo."
 
-#: pods/models.py:788
+#: pods/models.py:808
 msgid "End field and start field can't be equal."
 msgstr "Le commencement et la fin ne peuvent être équivalents."
 
-#: pods/models.py:806 pods/templates/videos/video_enrich.html:421
+#: pods/models.py:826 pods/templates/videos/video_enrich.html:421
 msgid "There is an overlap with the enrichment "
 msgstr "Il y a un chevauchement avec l'enrichissement "
 
-#: pods/models.py:841 pods/templates/videos/chapter/list_chapter.html:32
+#: pods/models.py:861 pods/templates/videos/chapter/list_chapter.html:32
 msgid "Start time"
 msgstr "Début de la vidéo"
 
-#: pods/models.py:841
+#: pods/models.py:862
 msgid "Start time of the chapter, in seconds."
 msgstr "Début d'affichage du chapitre, en secondes."
 
-#: pods/models.py:844
+#: pods/models.py:865
 msgid "Chapter"
 msgstr "Chapitre"
 
-#: pods/models.py:845
+#: pods/models.py:866
 msgid "Chapters"
 msgstr "Chapitres"
 
-#: pods/models.py:885
+#: pods/models.py:906
 msgid "There is an overlap with the chapter "
 msgstr "Il y a un chevauchement avec le chapitre "
 
-#: pods/models.py:915
+#: pods/models.py:936
 msgid "Favorite"
 msgstr "Favoris"
 
-#: pods/models.py:916
+#: pods/models.py:937
 msgid "Favorites"
 msgstr "Mes favoris"
 
-#: pods/models.py:929 pods/models.py:932
+#: pods/models.py:950 pods/models.py:953
 msgid "Note"
 msgstr "Note"
 
-#: pods/models.py:955
+#: pods/models.py:976
 msgid "Mediacourse"
 msgstr "Mediacours"
 
-#: pods/models.py:956
+#: pods/models.py:977
 msgid "Mediacourses"
 msgstr "Mediacours"
 
-#: pods/models.py:989 pods/models.py:996
+#: pods/models.py:1011 pods/models.py:1018
 msgid "Building"
 msgstr "Bâtiment"
 
-#: pods/models.py:990
+#: pods/models.py:1012
 msgid "Buildings"
 msgstr "Bâtiments"
 
-#: pods/models.py:997
+#: pods/models.py:1020
 msgid "description"
 msgstr "description"
 
-#: pods/models.py:1005
+#: pods/models.py:1031
 msgid "Live is accessible only to authenticated users."
 msgstr "La vidéo est accessible uniquement aux utilisateurs authentifiés."
 
-#: pods/models.py:1016
+#: pods/models.py:1044
 msgid "Recorder"
 msgstr "Enregistreur"
 
-#: pods/models.py:1017
+#: pods/models.py:1045
 msgid "Recorders"
 msgstr "Enregistreurs"
 
-#: pods/models.py:1025
+#: pods/models.py:1053
 msgid "User"
 msgstr "Utilisateur"
 
-#: pods/models.py:1028
+#: pods/models.py:1056
 msgid "Answer"
 msgstr "Réponse"
 
-#: pods/models.py:1044
+#: pods/models.py:1072
 msgid "Report"
 msgstr "Signaler"
 
-#: pods/models.py:1045
+#: pods/models.py:1073
 msgid "Reports"
 msgstr "Signalements"
 
@@ -2009,7 +1992,7 @@ msgstr[1] "%(counter)s vidéos"
 
 #: pods/templates/channels/channel.html:92
 #: pods/templates/channels/channel.html:94
-#: pods/templates/channels/channels_list.html:42
+#: pods/templates/channels/channels_list.html:39
 msgid "edit"
 msgstr "modifier"
 
@@ -2022,29 +2005,30 @@ msgid "no video found"
 msgstr "Aucune vidéo trouvée"
 
 #: pods/templates/channels/channel_edit.html:27
-#: pods/templates/channels/channel_edit.html:62
-#: pods/templates/channels/channel_edit.html:64
+#: pods/templates/channels/channel_edit.html:69
+#: pods/templates/channels/channel_edit.html:71
 msgid "Edition of the channel"
 msgstr "Édition de la chaîne"
 
-#: pods/templates/channels/channel_edit.html:94
-#: pods/templates/channels/channel_edit.html:95
-#: pods/templates/channels/channel_edit.html:175
-#: pods/templates/channels/channel_edit.html:176
+#: pods/templates/channels/channel_edit.html:121
+#: pods/templates/channels/channel_edit.html:148
+msgid "Delete this theme"
+msgstr "Supprimer ce thème"
+
+#: pods/templates/channels/channel_edit.html:156
+msgid "Add a new theme"
+msgstr "Ajouter un nouveau thème"
+
+#: pods/templates/channels/channel_edit.html:167
+#: pods/templates/channels/channel_edit.html:168
 #: pods/templates/videos/video_edit.html:361
 msgid "Save and return to previous page"
 msgstr "Enregistrer et revenir à la page précédente"
 
-#: pods/templates/channels/channel_edit.html:97
-#: pods/templates/channels/channel_edit.html:98
-#: pods/templates/channels/channel_edit.html:178
-#: pods/templates/channels/channel_edit.html:179
+#: pods/templates/channels/channel_edit.html:170
+#: pods/templates/channels/channel_edit.html:171
 msgid "Save and see channel"
 msgstr "Enregistrer et voir la chaîne"
-
-#: pods/templates/channels/channel_edit.html:164
-msgid "Add"
-msgstr "Ajouter"
 
 #: pods/templates/channels/channels.html:60
 #: pods/templates/channels/my_channels.html:52
@@ -2111,11 +2095,6 @@ msgstr "Ajouter un nouvel enregistrement"
 #: pods/templates/videos/video_enrich.html:444
 msgid "My videos"
 msgstr "Mes vidéos"
-
-#: pods/templates/owners/owners.html:24 pods/templates/owners/owners.html:31
-#: pods/templates/owners/owners.html:39 pods/templates/owners/owners.html:41
-msgid "Owners"
-msgstr "Propriétaires"
 
 #: pods/templates/owners/owners.html:63
 #, python-format
@@ -2545,8 +2524,8 @@ msgid "No data could be stored."
 msgstr "Aucune donnée n'a pu être enregistrée."
 
 #: pods/templates/videos/video_chapter.html:274
-#: pods/templates/videos/video_enrich.html:275 pods/views.py:181
-#: pods/views.py:418 pods/views.py:610 pods/views.py:612 pods/views.py:677
+#: pods/templates/videos/video_enrich.html:275 pods/views.py:186
+#: pods/views.py:423 pods/views.py:615 pods/views.py:617 pods/views.py:682
 msgid "The changes have been saved."
 msgstr "Les modifications ont été enregistrées."
 
@@ -2838,11 +2817,8 @@ msgid "Upload limit reached."
 msgstr "Limite de téléversement atteinte."
 
 #: pods/templates/videos/video_edit.html:343
-#, fuzzy, python-format
-#| msgid "You have reached the %(counter)s file per day upload limit."
-#| msgid_plural "You have reached the %(counter)s files per day upload limit."
 msgid "You have reached the %(counter)s file per day upload limit."
-msgid_plural "%(counter)s files per day upload limit."
+msgid_plural "You have reached the %(counter)s files per day upload limit."
 msgstr[0] "Vous avez atteint la limite de %(counter)s téléversement par jour."
 msgstr[1] "Vous avez atteint la limite de %(counter)s téléversements par jour."
 
@@ -3068,31 +3044,31 @@ msgstr "-- désolé, aucune traduction disponible --"
 msgid "You cannot edit this channel."
 msgstr "Vous ne pouvez pas modifier cette chaîne."
 
-#: pods/views.py:403 pods/views.py:1435
+#: pods/views.py:408 pods/views.py:1440
 msgid "You cannot watch this video."
 msgstr "Vous ne pouvez pas regarder cette vidéo."
 
-#: pods/views.py:447
+#: pods/views.py:452
 msgid "Incorrect password"
 msgstr "Mot de passe incorrect"
 
-#: pods/views.py:507
+#: pods/views.py:512
 msgid "The video has been added to your favorites."
 msgstr "La vidéo a été ajoutée à vos vidéos favorites."
 
-#: pods/views.py:512
+#: pods/views.py:517
 msgid "The video has been removed from your favorites."
 msgstr "La vidéo a été supprimée de vos vidéos favorites."
 
-#: pods/views.py:521 pods/views.py:594 pods/views.py:616
+#: pods/views.py:526 pods/views.py:599 pods/views.py:621
 msgid "You cannot acces this page."
 msgstr "Vous ne pouvez pas accéder à cette page."
 
-#: pods/views.py:532
+#: pods/views.py:537
 msgid "Video report confirmation"
 msgstr "Confirmation de signalement de vidéo"
 
-#: pods/views.py:534
+#: pods/views.py:539
 #, python-format
 msgid ""
 "\n"
@@ -3111,7 +3087,7 @@ msgstr ""
 "Cordialement.\n"
 "L'équipe Pod."
 
-#: pods/views.py:539
+#: pods/views.py:544
 #, python-format
 msgid ""
 "<p>You just report the video: \"%(title)s\" with this comment:<br/> "
@@ -3122,11 +3098,11 @@ msgstr ""
 "<br/> \"%(comment)s\".</p><p>Un courriel vient de nous être envoyé et votre "
 "signalement enregistré.</p><p>Cordialement</p><p>L'équipe Pod</p>"
 
-#: pods/views.py:549
+#: pods/views.py:554
 msgid "A video has just been reported."
 msgstr "Une vidéo vient d'être signalée."
 
-#: pods/views.py:551
+#: pods/views.py:556
 #, python-format
 msgid ""
 "The video intitled \"%(video_title)s\" has just been reported by "
@@ -3150,7 +3126,7 @@ msgstr ""
 "%(owner_email)s>.\n"
 "Vidéo mise en ligne le : %(video_date_added)s.\n"
 
-#: pods/views.py:565
+#: pods/views.py:570
 #, python-format
 msgid ""
 "<p>The video intitled \"%(video_title)s\" has just been reported by "
@@ -3171,58 +3147,58 @@ msgstr ""
 "href=\"mailto:%(owner_email)s\">%(owner_email)s&gt;</a>.<br/>Vidéo mise en "
 "ligne le : %(video_date_added)s.</p>"
 
-#: pods/views.py:585
+#: pods/views.py:590
 msgid "This video has been reported."
 msgstr "La vidéo a été signalée."
 
-#: pods/views.py:640
+#: pods/views.py:645
 msgid "You cannot edit this video."
 msgstr "Vous ne pouvez pas éditer cette vidéo."
 
-#: pods/views.py:735 pods/views.py:769 pods/views.py:903 pods/views.py:1034
+#: pods/views.py:740 pods/views.py:774 pods/views.py:908 pods/views.py:1039
 msgid "You cannot complement this video."
 msgstr "Vous ne pouvez pas compléter cette vidéo."
 
-#: pods/views.py:827 pods/views.py:960 pods/views.py:1093
+#: pods/views.py:832 pods/views.py:965 pods/views.py:1098
 msgid "Please correct errors"
 msgstr "Veuillez corriger les erreurs."
 
-#: pods/views.py:1169
+#: pods/views.py:1174
 msgid "You cannot chapter this video."
 msgstr "Vous ne pouvez pas chapitrer cette vidéo."
 
-#: pods/views.py:1215 pods/views.py:1333
+#: pods/views.py:1220 pods/views.py:1338
 msgid "Please correct errors."
 msgstr "Veuillez corriger les erreurs."
 
-#: pods/views.py:1286
+#: pods/views.py:1291
 msgid "You cannot enrich this video."
 msgstr "Vous ne pouvez pas enrichir cette vidéo."
 
-#: pods/views.py:1397
+#: pods/views.py:1402
 msgid "You cannot delete this video."
 msgstr "Vous ne pouvez pas supprimer cette vidéo."
 
-#: pods/views.py:1413
+#: pods/views.py:1418
 msgid "The video has been deleted."
 msgstr "La vidéo a été supprimée."
 
-#: pods/views.py:1620
+#: pods/views.py:1625
 msgid "Mediapath should be indicated."
 msgstr "MediaPath doit être indiqué."
 
-#: pods/views.py:1644
+#: pods/views.py:1649
 msgid ""
 "Your publication is saved. Adding it to your videos will be in a few minutes."
 msgstr ""
 "Votre publication est enregistrée. Son ajout à vos vidéos se fera dans "
 "quelques minutes."
 
-#: pods/views.py:1701
+#: pods/views.py:1706
 msgid "Recording"
 msgstr "En cours d'enregistrement"
 
-#: pods/views.py:1703
+#: pods/views.py:1708
 #, python-format
 msgid ""
 "Hello, \n"
@@ -3248,7 +3224,7 @@ msgstr ""
 "\n"
 "Cordialement"
 
-#: pods/views.py:1707
+#: pods/views.py:1712
 #, python-format
 msgid ""
 "Hello, <p>a new mediacourse has just be added on %(title_site)s from the "
@@ -3262,7 +3238,7 @@ msgstr ""
 "%(link_url)s</a><br/><i>Si le lien n'est pas actif, il faut le copier-coller "
 "dans la barre d'adresse de votre navigateur.</i><p><p>Cordialement</p>"
 
-#: pods/views.py:1714
+#: pods/views.py:1719
 msgid "New mediacourse added."
 msgstr "Nouveaux médiacours ajoutés."
 

--- a/traduction/djangojs.po
+++ b/traduction/djangojs.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=iso-8859-1\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
+"X-Generator: Poedit 1.8.9\n"
+
+#, javascript-format
+msgid "Available %s"
+msgstr "%s disponibles"
+
+#, javascript-format
+msgid "Chosen %s"
+msgstr "%s choisis"


### PR DESCRIPTION
This branch also:
- allows a staff member (*) channel owner to add / remove channel users via the admin « filter_horizontal » widget;
- removes channel / theme headband edition for non-staff member channel owners;
- sets channel visibility setting hideable to owners via « settings.py »;
- add an « Owners column » to admin channel list page, with clickable username that shows the user edit page;
- lists channel users with their first name, last name and username (instead of username only) in admin channel list and owner edition pages;
- introduces a new « djangojs.po » file for dynamic JS L10N.

Previous owner data is preserved via the included migration file.

![capture d ecran 2016-09-15 a 19 05 56](https://cloud.githubusercontent.com/assets/10742818/18559490/c16cb064-7b77-11e6-87a7-29c77f194412.png)


(*) Django Admin does not perform any dynamic javascript localization for non-staff users as they never reach the admin pages ("/admin/jsi18n/" versus "/dynamic-media/jsi18n/"). This causes all selector texts to remain in english when channel owner is not staff. The simpler way to solve this was to remove the ability to add / remove channel users for non-staff channel owners… which makes sense anyway.

