### PR TITLE
Feature: dublin core reaches 12 tags

### DIFF
--- a/pod_project/pod_project/settings-sample.py
+++ b/pod_project/pod_project/settings-sample.py
@@ -199,6 +199,14 @@ WEBTV = '<a href="http://webtv.univ.fr" id="webtv" class="btn btn-info btn-sm">'
 
 
 ##
+# Dublin Core :
+#
+#   rights :    licence CC pour les contenus publics
+#
+DC_RIGHTS = "CC-By-ND-NC"
+
+
+##
 # Taille maxi fichier téléversable :
 #
 #   ce paramètre est une chaîne contenant un chiffre suivi d'une unité (Mo ou Go),
@@ -282,6 +290,7 @@ TEMPLATE_CUSTOM = 'custom'  # None
 
 # Constantes utilisables depuis les templates
 TEMPLATE_VISIBLE_SETTINGS = (
+    'DC_RIGHTS',
     'DEFAULT_IMG',
     'FILTER_USER_MENU',
     'FMS_LIVE_URL',

--- a/pod_project/pod_project/settings-sample.py
+++ b/pod_project/pod_project/settings-sample.py
@@ -201,8 +201,10 @@ WEBTV = '<a href="http://webtv.univ.fr" id="webtv" class="btn btn-info btn-sm">'
 ##
 # Dublin Core :
 #
-#   rights :    licence CC pour les contenus publics
+#   coverage        nom, ville et pays de l'établissement
+#   rights          licence CC pour les contenus publics
 #
+DC_COVERAGE = TITLE_ETB + " - Ville - Pays"
 DC_RIGHTS = "CC-By-ND-NC"
 
 
@@ -290,6 +292,7 @@ TEMPLATE_CUSTOM = 'custom'  # None
 
 # Constantes utilisables depuis les templates
 TEMPLATE_VISIBLE_SETTINGS = (
+    'DC_COVERAGE',
     'DC_RIGHTS',
     'DEFAULT_IMG',
     'FILTER_USER_MENU',

--- a/pod_project/pods/templates/videos/video.html
+++ b/pod_project/pods/templates/videos/video.html
@@ -118,6 +118,7 @@ $(document).on('click', '#button_video_favorite', function (event) {
     <meta name="dc.type" content="{{ video.get_mediatype|first }}" />
     <meta name="dc.identifier" content="{{ request.build_absolute_uri }}" />
     <meta name="dc.language" content="{{ video.main_lang|upper }}" />
+    <meta name="dc.coverage" content="{{DC_COVERAGE}}" />
     {% if not video.is_restricted and not video.password %}<meta name="dc.rights" content="{{DC_RIGHTS}}" />{% endif %}
     <!-- /Dublin Core -->
     {% endif %}

--- a/pod_project/pods/templates/videos/video.html
+++ b/pod_project/pods/templates/videos/video.html
@@ -117,6 +117,7 @@ $(document).on('click', '#button_video_favorite', function (event) {
     {% if video.date_added %}<meta name="dc.date" content="{{ video.date_added|date:'Y/m/d' }}" />{% endif %}
     <meta name="dc.type" content="{{ video.get_mediatype|first }}" />
     <meta name="dc.identifier" content="{{ request.build_absolute_uri }}" />
+    <meta name="dc.language" content="{{ video.main_lang|upper }}" />
     {% if not video.is_restricted and not video.password %}<meta name="dc.rights" content="CC-By-ND-NC" />{% endif %}
     <!-- /Dublin Core -->
     {% endif %}

--- a/pod_project/pods/templates/videos/video.html
+++ b/pod_project/pods/templates/videos/video.html
@@ -118,7 +118,7 @@ $(document).on('click', '#button_video_favorite', function (event) {
     <meta name="dc.type" content="{{ video.get_mediatype|first }}" />
     <meta name="dc.identifier" content="{{ request.build_absolute_uri }}" />
     <meta name="dc.language" content="{{ video.main_lang|upper }}" />
-    {% if not video.is_restricted and not video.password %}<meta name="dc.rights" content="CC-By-ND-NC" />{% endif %}
+    {% if not video.is_restricted and not video.password %}<meta name="dc.rights" content="{{DC_RIGHTS}}" />{% endif %}
     <!-- /Dublin Core -->
     {% endif %}
 {% endblock %}

--- a/pod_project/pods/templates/videos/video.html
+++ b/pod_project/pods/templates/videos/video.html
@@ -113,7 +113,7 @@ $(document).on('click', '#button_video_favorite', function (event) {
     {% if video.discipline.all %}<meta name="dc.subject" content="{% for disc in video.discipline.all %}{{ disc.title }}{% if not forloop.last %}, {% endif %}{% endfor %}" />{% endif %}
     {% if video.description %}<meta name="dc.description" content="{{ video.description|metaformat|safe|striptags|truncatechars:300 }}" />{% endif %}
     {% if TITLE_ETB %}<meta name="dc.publisher" content="{{TITLE_ETB}}" />{% endif %}
-    {% if video.contributorpods_set.all %}<meta name="dc.contributor" content="{% for contrib in video.contributorpods_set.all %}{{ contrib.name }} {% if contrib.role %}({% trans contrib.role %}){%endif%}{% if not forloop.last %}, {% endif %}{% endfor %}" />{% endif %}
+    {% if video.contributorpods_set.all %}<meta name="dc.contributor" content="{% for contrib in video.contributorpods_set.all %}{{ contrib.name }} {% if contrib.role %}({{ contrib.role }}){%endif%}{% if not forloop.last %}, {% endif %}{% endfor %}" />{% endif %}
     {% if video.date_added %}<meta name="dc.date" content="{{ video.date_added|date:'Y/m/d' }}" />{% endif %}
     <meta name="dc.type" content="{{ video.get_mediatype|first }}" />
     <meta name="dc.identifier" content="{{ request.build_absolute_uri }}" />


### PR DESCRIPTION
- Adds « dc.language »;
- adds « dc.coverage » from settings;
- « dc.rights » is now taken from settings;
- removes L10N for « dc.contributor » role (which remains in english).

Remaining tags:
- « dc.format »;
- « dc.relation ».