### PR TITLE
Feature: more info in admin user list

### DIFF
--- a/pod_project/core/admin.py
+++ b/pod_project/core/admin.py
@@ -80,6 +80,7 @@ class UserAdmin(UserAdmin):
         'last_name',
         'first_name',
         'clickable_email',
+        'date_joined',
         'last_login',
         'is_active',
         'is_staff',

--- a/pod_project/core/admin.py
+++ b/pod_project/core/admin.py
@@ -26,6 +26,8 @@ from django.contrib.flatpages.models import FlatPage
 from ckeditor.widgets import CKEditorWidget
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
+from django.utils.translation import ugettext_lazy as _
+from django.utils.html import format_html
 from core.models import UserProfile, PagesMenuBas, EncodingType, ContactUs
 
 
@@ -66,11 +68,18 @@ class UserProfileInline(admin.StackedInline):
 # Define a new User admin
 
 class UserAdmin(UserAdmin):
+
+    def clickable_email(self, obj):
+        email = obj.email
+        return format_html('<a href="mailto:{}">{}</a>', email, email)
+
+    clickable_email.allow_tags = True
+    clickable_email.short_description = _('Email')
     list_display = (
         'username',
         'last_name',
         'first_name',
-        'email',
+        'clickable_email',
         'last_login',
         'is_active',
         'is_staff',

--- a/pod_project/core/admin.py
+++ b/pod_project/core/admin.py
@@ -6,7 +6,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -53,20 +53,31 @@ admin.site.register(FlatPage, CustomFlatPageAdmin)
 
 admin.site.register(PagesMenuBas)
 
+
 # Define an inline admin descriptor for Employee model
 # which acts a bit like a singleton
-
 
 class UserProfileInline(admin.StackedInline):
     model = UserProfile
     can_delete = False
     verbose_name_plural = 'profiles'
 
+
 # Define a new User admin
 
-
 class UserAdmin(UserAdmin):
+    list_display = (
+        'username',
+        'last_name',
+        'first_name',
+        'email',
+        'last_login',
+        'is_active',
+        'is_staff',
+        'is_superuser'
+    )
     inlines = (UserProfileInline, )
+
 
 # Re-register UserAdmin
 admin.site.unregister(User)

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-21 15:31+0200\n"
-"PO-Revision-Date: 2016-09-22 12:17+0200\n"
+"PO-Revision-Date: 2016-09-23 13:57+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: ESUP POD <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -191,6 +191,7 @@ msgstr "réglages d'encodage"
 msgid "Name"
 msgstr "Nom"
 
+#: core/admin.py:77
 #: core/models.py:270
 msgid "Email"
 msgstr "Courriel"


### PR DESCRIPTION
Adds new columns in admin user list:
-  last_login,
- is_active,
- is_superuser;

![capture d ecran 2016-09-23 a 14 01 55](https://cloud.githubusercontent.com/assets/10742818/18785049/552ec688-8196-11e6-935c-8267ce2886eb.png)


and makes « email » column clickable.