### PR TITLE
Feature: users can be authors, owners, or simply people posting content.

### DIFF
--- a/pod_project/core/templates/navbar.html
+++ b/pod_project/core/templates/navbar.html
@@ -73,7 +73,7 @@ voir http://www.gnu.org/licenses/
                 <!-- end channel -->
                 <li class="dropdown">
                     <a href="{% url 'owners' %}" class="dropdown-toggle" data-toggle="dropdown">
-                        {% trans "Authors"%}<b class="caret"></b>
+                        {% trans "Users"%}<b class="caret"></b>
                     </a>
                     <ul class="dropdown-menu  multi-level">
                         <li class="divider"></li>
@@ -88,7 +88,7 @@ voir http://www.gnu.org/licenses/
                        <li class="divider"></li>
                        <li>
                            <a href="{% url 'owners' %}">
-                               {% trans "Authors"%}
+                               {% trans "Users"%}
                                <span class="glyphicon glyphicon-list-alt pull-right"></span>
                            </a>
                        </li>

--- a/pod_project/pods/templates/owners/owners.html
+++ b/pod_project/pods/templates/owners/owners.html
@@ -21,14 +21,14 @@ voir http://www.gnu.org/licenses/
 {% endcomment %}
 {% load i18n staticfiles %}
 
-{% block bootstrap3_title %}{% trans 'Owners' %}{% endblock bootstrap3_title %}
+{% block bootstrap3_title %}{% trans 'Users' %}{% endblock bootstrap3_title %}
 
 {% block bootstrap3_extra_head %}{% endblock bootstrap3_extra_head %}
 
 {% block opengraph %}
     <meta name="description" content="">
 	<!-- Open Graph data -->
-	<meta property="og:title" content="{% trans 'Owners' %}" />
+	<meta property="og:title" content="{% trans 'Users owning content' %}" />
 	<meta property="og:type" content="article" />
 	<meta property="og:url" content="{{ request.build_absolute_uri }}" />
 	<meta property="og:image" content="//{{ request.META.HTTP_HOST }}{% static 'images/share.png' %}" />
@@ -36,9 +36,9 @@ voir http://www.gnu.org/licenses/
 	<meta property="og:site_name" content="{{ TITLE_SITE }}" />
 {% endblock %}
 
-{% block article_title %}{% trans 'Owners' %}{% endblock article_title %}
+{% block article_title %}{% trans 'Users' %}{% endblock article_title %}
 
-{% block breadcrumbs %}{{ block.super }} <li class="active">{% trans 'Owners' %}</li>{% endblock breadcrumbs %}
+{% block breadcrumbs %}{{ block.super }} <li class="active">{% trans 'Users' %}</li>{% endblock breadcrumbs %}
 
 {% block mainToolbar %}
     <div class="well well-sm">
@@ -60,7 +60,7 @@ voir http://www.gnu.org/licenses/
         {% block stats %}
             <div class="col-sm-4 text-right">
                 <div class="resultschannel">
-                    {% blocktrans count counter=owners.paginator.count %}{{ counter }} owner{% plural %}{{ counter }} owners{% endblocktrans %}
+                    {% blocktrans count counter=owners.paginator.count %}{{ counter }} user having posted{% plural %}{{ counter }} users having posted{{% endblocktrans %}
                 </div>
                 <div class="results">
                     {% blocktrans count counter=video_count %}{{ counter }} video{% plural %}{{ counter }} videos{% endblocktrans %}

--- a/pod_project/pods/templates/owners/owners_list.html
+++ b/pod_project/pods/templates/owners/owners_list.html
@@ -6,7 +6,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -25,16 +25,13 @@ voir http://www.gnu.org/licenses/
 {% for owner in owners %}
 	<div class="video-thumb col-xs-6 col-md-4">
 	    <a href="{% url "videos" %}?owner={{owner.username}}" title="{{owner.get_full_name}} ({{owner.video_count}})">
-		<span class="poster">
+    		<span class="poster">
 			{% if owner.userprofile.image %}
-			    <span class="play text-center">
-    				<span class="glyphicon glyphicon-play-circle"></span>
-    			</span>
                 <img src="{% thumbnail owner.userprofile.image 285x160 crop upscale subject_location=owner.userprofile.image.subject_location %}" alt="{{owner.get_full_name}}" class="preview">
             {%else%}
                 <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{owner.get_full_name}}" class="preview">
             {% endif %}
-		</span>
+    		</span>
 		{% if owner.get_full_name %}
 		<h5>{{owner.get_full_name|safe|striptags|truncatechars:32}} ({% video_count owner %})</h5>
 		{% else %}

--- a/pod_project/pods/templates/videos/videos.html
+++ b/pod_project/pods/templates/videos/videos.html
@@ -49,7 +49,7 @@ voir http://www.gnu.org/licenses/
 <form action="{% url 'videos' %}" class="form filtres" method="get" id="filters" style="display: block;">
 
 <fieldset>
-<legend><span class="glyphicon glyphicon-user"></span> {% trans "Authors" %}</legend>
+<legend><span class="glyphicon glyphicon-user"></span> {% trans "Users" %}</legend>
 <div class="form-group">
 <input placeholder="{% trans "Search" %}" id="ownerbox" type="text" class="form-control">
 </div>

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-21 15:31+0200\n"
-"PO-Revision-Date: 2016-09-23 14:57+0200\n"
+"PO-Revision-Date: 2016-09-26 12:18+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: ESUP POD <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -619,11 +619,6 @@ msgstr "Connexion"
 #: pods/templates/videos/video.html:141
 msgid "Channels"
 msgstr "Chaînes"
-
-#: core/templates/navbar.html:76 core/templates/navbar.html.py:91
-#: pods/templates/videos/videos.html:52
-msgid "Authors"
-msgstr "Auteurs"
 
 #: core/templates/navbar.html:99 core/templates/navbar.html.py:109
 #: pods/models.py:173 pods/templates/types/types.html:24
@@ -1422,9 +1417,7 @@ msgstr "Doctorat"
 msgid "Other"
 msgstr "Autre"
 
-#: pods/admin.py:54 pods/models.py:72 pods/templates/owners/owners.html:24
-#: pods/templates/owners/owners.html:31 pods/templates/owners/owners.html:39
-#: pods/templates/owners/owners.html:41
+#: pods/admin.py:54 pods/models.py:72
 msgid "Owners"
 msgstr "Propriétaires"
 
@@ -1459,7 +1452,14 @@ msgstr "Couleur de fond"
 msgid "Extra style"
 msgstr "Style supplémentaire"
 
+#: pods/templates/owners/owners.html:31
+msgid "Users owning content"
+msgstr "Utilisateurs propriétaires de contenu"
+
+#: core/templates/navbar.html:76 core/templates/navbar.html.py:91
 #: pods/models.py:75 pods/templates/channels/channel_edit.html:178
+#: pods/templates/owners/owners.html:24 pods/templates/owners/owners.html:39
+#: pods/templates/owners/owners.html:41 pods/templates/videos/videos.html:52
 msgid "Users"
 msgstr "Utilisateurs"
 
@@ -2099,10 +2099,10 @@ msgstr "Mes vidéos"
 
 #: pods/templates/owners/owners.html:63
 #, python-format
-msgid "%(counter)s owner"
-msgid_plural "%(counter)s owners"
-msgstr[0] "%(counter)s propriétaire"
-msgstr[1] "%(counter)s propriétaires"
+msgid "%(counter)s user having posted"
+msgid_plural "%(counter)s users having posted"
+msgstr[0] "%(counter)s utilisateur ayant posté"
+msgstr[1] "%(counter)s utilisateurs ayant posté"
 
 #: pods/templates/pagination.html:40
 msgid "Show all"


### PR DESCRIPTION
This branch names people posting content « Users » in the front-end, as it is in the back-end.

This way, users posting content they do not own will not be called "owners", nor "authors".

<img width="305" alt="capture d ecran 2016-09-26 a 14 47 39" src="https://cloud.githubusercontent.com/assets/10742818/18834960/0f28d222-83f9-11e6-9e52-2df45f701823.png">
