### PR TITLE
Fixes navbar icon display with Firefox (the good one…)

### DIFF
--- a/pod_project/core/templates/navbar.html
+++ b/pod_project/core/templates/navbar.html
@@ -64,8 +64,8 @@ voir http://www.gnu.org/licenses/
                         <li class="divider"></li>
                         <li>
                             <a href="{% url 'channels' %}">
-                                {% trans "Channels"%}
                                 <span class="glyphicon glyphicon-list-alt pull-right"></span>
+                                {% trans "Channels"%}
                             </a>
                         </li>
                     </ul>
@@ -88,8 +88,8 @@ voir http://www.gnu.org/licenses/
                        <li class="divider"></li>
                        <li>
                            <a href="{% url 'owners' %}">
-                               {% trans "Users"%}
                                <span class="glyphicon glyphicon-list-alt pull-right"></span>
+                               {% trans "Users"%}
                            </a>
                        </li>
                     </ul>
@@ -106,8 +106,8 @@ voir http://www.gnu.org/licenses/
                         <li class="divider"></li>
                         <li>
                             <a href="{% url 'types' %}">
-                                {% trans "Types"%}
                                 <span class="glyphicon glyphicon-list-alt pull-right"></span>
+                                {% trans "Types"%}
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
**This one replaces #138, which doesn't have any content (sorry!).**

Navbar icons will stay on the same line.

_Before:_
<img width="149" alt="capture d ecran 2016-09-26 a 15 30 53" src="https://cloud.githubusercontent.com/assets/10742818/18835997/3dc8e7d4-83fe-11e6-9dfc-0fd3c675fb71.png">


_After:_
<img width="163" alt="capture d ecran 2016-09-26 a 15 01 34" src="https://cloud.githubusercontent.com/assets/10742818/18835952/ff823868-83fd-11e6-9f45-19b6acef7410.png">
