### PR TITLE
add a status page for load balancer

### DIFF
--- a/pod_project/core/views.py
+++ b/pod_project/core/views.py
@@ -24,7 +24,7 @@ voir http://www.gnu.org/licenses/
 from django.shortcuts import render
 from core.forms import FileBrowseForm, ProfileForm, ContactUsModelForm
 from django.shortcuts import render_to_response, get_object_or_404
-from django.http import Http404, HttpResponseRedirect
+from django.http import Http404, HttpResponseRedirect, HttpResponse
 from django.template import RequestContext
 
 from django.utils.translation import ugettext_lazy as _
@@ -203,6 +203,7 @@ def contact_us(request):
                 }
             msg_txt = strip_tags(u'%s' %msg_html)
 
+
             email_msg = EmailMultiAlternatives(
                 "[" + settings.TITLE_SITE + "] %s %s" %(_('your message intitled'), contact.subject), msg_txt, settings.HELP_MAIL, [contact.email])
             email_msg.attach_alternative(msg_html, "text/html")
@@ -224,3 +225,6 @@ def contact_us(request):
                               {'flatpage': flatpage, },
                               context_instance=RequestContext(request))
 
+def status(request):
+    """ simple status page who returns a code 200 """
+    return HttpResponse(status=200)

--- a/pod_project/pod_project/urls-sample.py
+++ b/pod_project/pod_project/urls-sample.py
@@ -23,6 +23,8 @@ urlpatterns = patterns(
     url(r'^accounts/cas/logout/$',
         'django_cas_gateway.views.logout', name='cas_logout'),
     url(r'^user/', 'core.views.user_profile', name='user_profile'),
+    # STATUS
+    url(r'^status/', 'core.views.status', name='status'),
 
     url(r'^owner_channels_list/', 'pods.views.owner_channels_list',
         name='owner_channels_list'),

--- a/pod_project/pod_project/urls.py
+++ b/pod_project/pod_project/urls.py
@@ -23,6 +23,8 @@ urlpatterns = patterns(
     url(r'^accounts/cas/logout/$',
         'django_cas_gateway.views.logout', name='cas_logout'),
     url(r'^user/', 'core.views.user_profile', name='user_profile'),
+    # STATUS
+    url(r'^status/', 'core.views.status', name='status'),
 
     url(r'^owner_channels_list/', 'pods.views.owner_channels_list',
         name='owner_channels_list'),


### PR DESCRIPTION
Bonjour,

J'ai rajouté une simple page "status/" toute bête qui renvoie juste un code 200.

Dans notre architecture avec "load balancer", ça permet au "load balancer" de requêter cette url pour savoir si l'application django est up ou down. Vu que le load balancer requête toutes les 15 secondes, il vaut mieux éviter d'utiliser la page d’accueil (requêtes sql inutiles, transfert de données inutiles).

Ça pourra servir pour les universités qui vont adopter ce type d'architecture.

Morgan
