### PR TITLE
Feature: localization improvements and fixes for 1.5.1

### DIFF
--- a/pod_project/pod_project/settings-sample.py
+++ b/pod_project/pod_project/settings-sample.py
@@ -105,7 +105,6 @@ LANGUAGES = (
     ('fr', 'Français'),
     ('en', 'English')
 )
-DEFAULT_LANGUAGE = 1
 
 LOCALE_PATHS = (
     os.path.join(BASE_DIR, 'locale'),

--- a/pod_project/pods/templates/owners/owners.html
+++ b/pod_project/pods/templates/owners/owners.html
@@ -60,7 +60,7 @@ voir http://www.gnu.org/licenses/
         {% block stats %}
             <div class="col-sm-4 text-right">
                 <div class="resultschannel">
-                    {% blocktrans count counter=owners.paginator.count %}{{ counter }} user having posted{% plural %}{{ counter }} users having posted{{% endblocktrans %}
+                    {% blocktrans count counter=owners.paginator.count %}{{ counter }} user having posted{% plural %}{{ counter }} users having posted{% endblocktrans %}
                 </div>
                 <div class="results">
                     {% blocktrans count counter=video_count %}{{ counter }} video{% plural %}{{ counter }} videos{% endblocktrans %}

--- a/pod_project/pods/templates/videos/video.html
+++ b/pod_project/pods/templates/videos/video.html
@@ -108,7 +108,7 @@ $(document).on('click', '#button_video_favorite', function (event) {
 {% block dublincore %}
     {% if not video.is_draft %}{% load pod_filters %}
     <!-- Dublin Core -->
-    {% include 'videos/dublincore.html' with xml=False %}     
+    {% include 'videos/dublincore.html' with xml=False %}
     <!-- /Dublin Core -->
     {% endif %}
 {% endblock %}
@@ -415,7 +415,7 @@ $(document).on('click', '#button_video_favorite', function (event) {
                                 <form class="row">
                                     <div class="form-group col-sm-8">
                                         <label for="txtintegration">
-                                            {% trans 'Copy the content of the text box and paste it in the page' %}
+                                            {% trans 'Copy the content of this text box and paste it in the page' %}
                                             <textarea name="txtintegration" id="txtintegration" class="form-control" rows="4">&lt;iframe src="//{{ request.META.HTTP_HOST }}{% url 'video' slug=video.slug %}?is_iframe=true&amp;size=240" width="640" height="360" style="padding: 0; margin: 0; border:0" allowfullscreen &gt;&lt;/iframe&gt;</textarea>
                                         </label>
                                     </div>

--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -340,7 +340,7 @@ var name = "";
         <div class="panel panel-warning">
             <div class="panel-heading">{% trans "Upload limit reached." %}</div>
             <div class="panel-body">
-            <p>{% blocktrans count MAX_DAILY_USER_UPLOADS as counter %}You have reached the {{ counter }} file per day upload limit.{% plural %}{{ counter }} files per day upload limit.{% endblocktrans %}</p>
+            <p>{% blocktrans count MAX_DAILY_USER_UPLOADS as counter %}You have reached the {{ counter }} file per day upload limit.{% plural %}You have reached the {{ counter }} files per day upload limit.{% endblocktrans %}</p>
             <p>{% trans "Please come back tomorrow!" %}</p>
             </div>
         </div>

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-21 15:31+0200\n"
-"PO-Revision-Date: 2016-09-26 12:18+0200\n"
+"PO-Revision-Date: 2016-09-29 11:20+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: ESUP POD <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -2453,8 +2453,8 @@ msgid "Social Networks"
 msgstr "Réseaux Sociaux"
 
 #: pods/templates/videos/video.html:418
-msgid "Copy the content of the text box and paste it in the page"
-msgstr "Copiez le contenu de la zone de texte et coller le dans la page"
+msgid "Copy the content of this text box and paste it in the page"
+msgstr "Copiez le contenu de cette zone de texte et collez-le dans la page"
 
 #: pods/templates/videos/video.html:424
 msgid "Video size"


### PR DESCRIPTION
- Improves « Embed/Share » textarea label,
- fixes 2 errors in templates strings,
- removes « DEFAULT_LANGUAGE » from settings as it is now [taken from « MODELTRANSLATION_DEFAULT_LANGUAGE » by « django-modeltranslation »](http://pydoc.net/Python/django-modeltranslation/0.11/modeltranslation.settings/).


<img width="489" alt="capture d ecran 2016-09-29 a 11 57 41" src="https://cloud.githubusercontent.com/assets/10742818/18949510/f35d416e-863b-11e6-81d6-9f84c6aff6b0.png">
