### PR TITLE
Feature: remove play icon in non video list templates

### DIFF
--- a/pod_project/pods/templates/channels/channels_list.html
+++ b/pod_project/pods/templates/channels/channels_list.html
@@ -26,11 +26,11 @@ voir http://www.gnu.org/licenses/
 	<div class="video-thumb col-xs-6 col-md-4">
 	    <a href="{% url "channel" slug_c=channel.slug %}" title="{{channel.title}} ({{channel.video_count}})">
     		<span class="poster">
-    			{% if channel.headband %}
-                    <img alt="img" src="{% thumbnail channel.headband 285x160 crop upscale subject_location=channel.headband.subject_location %}" alt="{{channel.title}}" class="preview">
-                {%else%}
-                    <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{channel.title}}">
-                {% endif %}
+			{% if channel.headband %}
+                <img alt="img" src="{% thumbnail channel.headband 285x160 crop upscale subject_location=channel.headband.subject_location %}" alt="{{channel.title}}" class="preview">
+            {%else%}
+                <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{channel.title}}">
+            {% endif %}
     		</span>
     		<h5>{{channel.title|safe|striptags|truncatechars:32}} ({{channel.video_count}})</h5>
 		</a>

--- a/pod_project/pods/templates/disciplines/disciplines_list.html
+++ b/pod_project/pods/templates/disciplines/disciplines_list.html
@@ -5,7 +5,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -26,14 +26,11 @@ voir http://www.gnu.org/licenses/
 	<div class="video-thumb col-xs-6 col-md-4">
 	    <a href="{% url "videos" %}?discipline={{discipline.slug}}" title="{{discipline.title}} ({{discipline.video_count}})">
 		<span class="poster">
-			{% if discipline.headband %}
-                <span class="play text-center">
-    				<span class="glyphicon glyphicon-play-circle"></span>
-    			</span>
-                <img src="{% thumbnail discipline.headband 285x160 crop upscale subject_location=discipline.headband.subject_location %}" alt="{{discipline.title}}" class="preview">
-            {%else%}
-                <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{discipline.title}}">
-            {% endif %}
+		{% if discipline.headband %}
+            <img src="{% thumbnail discipline.headband 285x160 crop upscale subject_location=discipline.headband.subject_location %}" alt="{{discipline.title}}" class="preview">
+        {%else%}
+            <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{discipline.title}}">
+        {% endif %}
 		</span>
 		<h5>{{discipline.title|safe|striptags|truncatechars:32}} ({{discipline.video_count}})</h5>
 		</a>

--- a/pod_project/pods/templates/disciplines/disciplines_list.html
+++ b/pod_project/pods/templates/disciplines/disciplines_list.html
@@ -25,14 +25,14 @@ voir http://www.gnu.org/licenses/
 {% for discipline in disciplines %}
 	<div class="video-thumb col-xs-6 col-md-4">
 	    <a href="{% url "videos" %}?discipline={{discipline.slug}}" title="{{discipline.title}} ({{discipline.video_count}})">
-		<span class="poster">
-		{% if discipline.headband %}
-            <img src="{% thumbnail discipline.headband 285x160 crop upscale subject_location=discipline.headband.subject_location %}" alt="{{discipline.title}}" class="preview">
-        {%else%}
-            <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{discipline.title}}">
-        {% endif %}
-		</span>
-		<h5>{{discipline.title|safe|striptags|truncatechars:32}} ({{discipline.video_count}})</h5>
+    		<span class="poster">
+    		{% if discipline.headband %}
+                <img src="{% thumbnail discipline.headband 285x160 crop upscale subject_location=discipline.headband.subject_location %}" alt="{{discipline.title}}" class="preview">
+            {%else%}
+                <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{discipline.title}}">
+            {% endif %}
+    		</span>
+    		<h5>{{discipline.title|safe|striptags|truncatechars:32}} ({{discipline.video_count}})</h5>
 		</a>
 	</div>
 {%endfor%}

--- a/pod_project/pods/templates/owners/owners_list.html
+++ b/pod_project/pods/templates/owners/owners_list.html
@@ -33,9 +33,9 @@ voir http://www.gnu.org/licenses/
             {% endif %}
     		</span>
 		{% if owner.get_full_name %}
-		<h5>{{owner.get_full_name|safe|striptags|truncatechars:32}} ({% video_count owner %})</h5>
+            <h5>{{owner.get_full_name|safe|striptags|truncatechars:32}} ({% video_count owner %})</h5>
 		{% else %}
-		<h5>{{owner.username|safe|striptags|truncatechars:32}} ({% video_count owner %})</h5>
+            <h5>{{owner.username|safe|striptags|truncatechars:32}} ({% video_count owner %})</h5>
 		{% endif %}
 		</a>
 	</div>

--- a/pod_project/pods/templates/types/types_list.html
+++ b/pod_project/pods/templates/types/types_list.html
@@ -25,14 +25,14 @@ voir http://www.gnu.org/licenses/
 {% for type in types %}
 	<div class="video-thumb col-xs-6 col-md-4">
 	    <a href="{% url "videos" %}?type={{type.slug}}" title="{{type.title}} ({{type.video_count}})">
-		<span class="poster">
-		{% if type.headband %}
-            <img src="{% thumbnail type.headband 285x160 crop upscale subject_location=type.headband.subject_location %}" alt="{{type.title}}" class="preview">
-        {%else%}
-            <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{owner.get_full_name}}" class="preview">
-        {% endif %}
-		</span>
-		<h5>{{type.title|truncatechars:50}} ({{type.video_count}})</h5>
+    		<span class="poster">
+    		{% if type.headband %}
+                <img src="{% thumbnail type.headband 285x160 crop upscale subject_location=type.headband.subject_location %}" alt="{{type.title}}" class="preview">
+            {%else%}
+                <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{owner.get_full_name}}" class="preview">
+            {% endif %}
+    		</span>
+    		<h5>{{type.title|truncatechars:50}} ({{type.video_count}})</h5>
 		</a>
 	</div>
 {%endfor%}

--- a/pod_project/pods/templates/types/types_list.html
+++ b/pod_project/pods/templates/types/types_list.html
@@ -5,7 +5,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -26,14 +26,11 @@ voir http://www.gnu.org/licenses/
 	<div class="video-thumb col-xs-6 col-md-4">
 	    <a href="{% url "videos" %}?type={{type.slug}}" title="{{type.title}} ({{type.video_count}})">
 		<span class="poster">
-			{% if type.headband %}
-			    <span class="play text-center">
-    				<span class="glyphicon glyphicon-play-circle"></span>
-    			</span>
-                <img src="{% thumbnail type.headband 285x160 crop upscale subject_location=type.headband.subject_location %}" alt="{{type.title}}" class="preview">
-            {%else%}
-                <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{owner.get_full_name}}" class="preview">
-            {% endif %}
+		{% if type.headband %}
+            <img src="{% thumbnail type.headband 285x160 crop upscale subject_location=type.headband.subject_location %}" alt="{{type.title}}" class="preview">
+        {%else%}
+            <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{owner.get_full_name}}" class="preview">
+        {% endif %}
 		</span>
 		<h5>{{type.title|truncatechars:50}} ({{type.video_count}})</h5>
 		</a>


### PR DESCRIPTION
As previously done in 1.5.0 for « Channels » and « Owners » (when another image than the default one is used).

Before:
<img width="289" alt="capture d ecran 2016-10-10 a 17 07 07" src="https://cloud.githubusercontent.com/assets/10742818/19242516/d2ea9360-8f13-11e6-8893-f2491f600ff9.png">

After:
<img width="289" alt="capture d ecran 2016-10-10 a 17 07 52" src="https://cloud.githubusercontent.com/assets/10742818/19242521/d92af4e0-8f13-11e6-8ac3-eba5437b844e.png">
