### PR TITLE
Bugfix: list images overfilling their containers

### DIFF
--- a/pod_project/pods/templates/channels/channels_list.html
+++ b/pod_project/pods/templates/channels/channels_list.html
@@ -24,7 +24,7 @@ voir http://www.gnu.org/licenses/
 <div id="video-list" class="row">
 {% for channel in channels %}
 	<div class="video-thumb col-xs-6 col-md-4">
-	    <a href="{% url "channel" slug_c=channel.slug %}" title="{{channel.title}} ({{channel.video_count}})">
+	    <a class="video-holder" href="{% url "channel" slug_c=channel.slug %}" title="{{channel.title}} ({{channel.video_count}})">
     		<span class="poster">
 			{% if channel.headband %}
                 <img alt="img" src="{% thumbnail channel.headband 285x160 crop upscale subject_location=channel.headband.subject_location %}" alt="{{channel.title}}" class="preview">

--- a/pod_project/pods/templates/disciplines/disciplines_list.html
+++ b/pod_project/pods/templates/disciplines/disciplines_list.html
@@ -24,7 +24,7 @@ voir http://www.gnu.org/licenses/
 <div id="video-list" class="row">
 {% for discipline in disciplines %}
 	<div class="video-thumb col-xs-6 col-md-4">
-	    <a href="{% url "videos" %}?discipline={{discipline.slug}}" title="{{discipline.title}} ({{discipline.video_count}})">
+	    <a class="video-holder" href="{% url "videos" %}?discipline={{discipline.slug}}" title="{{discipline.title}} ({{discipline.video_count}})">
     		<span class="poster">
     		{% if discipline.headband %}
                 <img src="{% thumbnail discipline.headband 285x160 crop upscale subject_location=discipline.headband.subject_location %}" alt="{{discipline.title}}" class="preview">

--- a/pod_project/pods/templates/owners/owners_list.html
+++ b/pod_project/pods/templates/owners/owners_list.html
@@ -24,7 +24,7 @@ voir http://www.gnu.org/licenses/
 <div id="video-list" class="row">
 {% for owner in owners %}
 	<div class="video-thumb col-xs-6 col-md-4">
-	    <a href="{% url "videos" %}?owner={{owner.username}}" title="{{owner.get_full_name}} ({{owner.video_count}})">
+	    <a class="video-holder" href="{% url "videos" %}?owner={{owner.username}}" title="{{owner.get_full_name}} ({{owner.video_count}})">
     		<span class="poster">
 			{% if owner.userprofile.image %}
                 <img src="{% thumbnail owner.userprofile.image 285x160 crop upscale subject_location=owner.userprofile.image.subject_location %}" alt="{{owner.get_full_name}}" class="preview">

--- a/pod_project/pods/templates/types/types_list.html
+++ b/pod_project/pods/templates/types/types_list.html
@@ -24,7 +24,7 @@ voir http://www.gnu.org/licenses/
 <div id="video-list" class="row">
 {% for type in types %}
 	<div class="video-thumb col-xs-6 col-md-4">
-	    <a href="{% url "videos" %}?type={{type.slug}}" title="{{type.title}} ({{type.video_count}})">
+	    <a class="video-holder" href="{% url "videos" %}?type={{type.slug}}" title="{{type.title}} ({{type.video_count}})">
     		<span class="poster">
     		{% if type.headband %}
                 <img src="{% thumbnail type.headband 285x160 crop upscale subject_location=type.headband.subject_location %}" alt="{{type.title}}" class="preview">


### PR DESCRIPTION
Channel / owners / types / disciplines list image do not behave as video thumbs due to a missing class on their parent A.

Before:
<img width="524" alt="capture d ecran 2016-10-10 a 18 18 26" src="https://cloud.githubusercontent.com/assets/10742818/19243570/6277add4-8f18-11e6-9d41-0801a49562d0.png">

After:
<img width="524" alt="capture d ecran 2016-10-10 a 18 19 12" src="https://cloud.githubusercontent.com/assets/10742818/19243580/6cd97460-8f18-11e6-8deb-ff3ac3576c39.png">
