### PR TITLE
Bugfix: player logo link reloads inside iframe

### DIFF
--- a/pod_project/core/static/js/player.js
+++ b/pod_project/core/static/js/player.js
@@ -287,21 +287,31 @@ function loadVideo() {
         /*************************************************************************/
         if ( player_logo_img ) {
 
-            var logoLink = document.createElement( 'a' ),
-                logoImg = document.createElement( 'img' );
+            var logoImg = document.createElement( 'img' );
 
-            logoLink.setAttribute( 'href', player_logo_url );
-            logoLink.setAttribute( 'target', "_blank" );
-            logoLink.setAttribute( 'title', player_logo_title );
-            logoLink.setAttribute( 'role', "link" );
-            logoLink.setAttribute( 'style', "font-size: 1.5em; font-weight: bold; line-height: 1.9em;" );
             logoImg.setAttribute( 'src', player_logo_img );
-            logoImg.setAttribute('alt', player_logo_alt);
+            logoImg.setAttribute( 'alt', player_logo_alt );
             logoImg.setAttribute( 'height', '90%' );
+            logoImg.setAttribute( 'style', "font-size: 1.6em; line-height: 1.9em; font-weight: bold;" );
 
-            logoLink.appendChild( logoImg );
+            if ( player_logo_url ) {
 
-            myPlayer.controlBar.el( ).appendChild( logoLink );
+                var logoLink = document.createElement( 'a' );
+
+                logoLink.setAttribute( 'href', player_logo_url );
+                logoLink.setAttribute( 'target', "_blank" );
+                logoLink.setAttribute( 'title', player_logo_title );
+                logoLink.setAttribute( 'role', "link" );
+
+                logoLink.appendChild( logoImg );
+
+                myPlayer.controlBar.el( ).appendChild( logoLink );
+
+            } else {
+
+                myPlayer.controlBar.el( ).appendChild( logoImg );
+
+            }
         }
         /*************************************************************************/
         start = decodeURIComponent($.urlParam('start'));

--- a/pod_project/core/static/js/player.js
+++ b/pod_project/core/static/js/player.js
@@ -101,8 +101,8 @@ function loadVideo() {
         if ($('ul#slides li[data-type!="None"]').length > 0) {
             myPlayer.displaySelector({
                 default_disp: '100/0',
-			    list_disp: list_disp
-			});
+                list_disp: list_disp
+            });
         }
         $('ul#slides').hide();
 
@@ -112,9 +112,9 @@ function loadVideo() {
                 list_chap[$(this).attr('data-start')] = $(this).attr('data-title');
             });
             myPlayer.chapterSelector({
-    			list_chap : list_chap
-			});
-			$('ul#chapters').hide();
+                list_chap : list_chap
+            });
+            $('ul#chapters').hide();
         }
 
         $('div.vjs-slide').hide();
@@ -291,6 +291,7 @@ function loadVideo() {
                 logoImg = document.createElement( 'img' );
 
             logoLink.setAttribute( 'href', player_logo_url );
+            logoLink.setAttribute( 'target', "_blank" );
             logoLink.setAttribute( 'title', player_logo_title );
             logoLink.setAttribute( 'role', "link" );
             logoLink.setAttribute( 'style', "font-size: 1.5em; font-weight: bold; line-height: 1.9em;" );

--- a/pod_project/pods/templates/videos/extraheadplayer.html
+++ b/pod_project/pods/templates/videos/extraheadplayer.html
@@ -81,7 +81,7 @@ voir http://www.gnu.org/licenses/
     {% endif %}
     {% if LOGO_PLAYER != '' %}
         var player_logo_img = '{% static LOGO_PLAYER %}',
-            player_logo_title = '{% blocktrans %}Click to reach this content on {{ TITLE_SITE }}.{% endblocktrans %}',
+            player_logo_title = '{% blocktrans %}Access this content on “{{ TITLE_SITE }}” in a new window / tab.{% endblocktrans %}',
             player_logo_alt = '{{ TITLE_SITE }}',
             player_logo_url = '{{ request.build_absolute_uri }}',
             pod_video_url = player_logo_url.split( '/' );

--- a/pod_project/pods/templates/videos/extraheadplayer.html
+++ b/pod_project/pods/templates/videos/extraheadplayer.html
@@ -82,8 +82,12 @@ voir http://www.gnu.org/licenses/
     {% if LOGO_PLAYER != '' %}
         var player_logo_img = '{% static LOGO_PLAYER %}',
             player_logo_title = '{% blocktrans %}Click to reach this content on {{ TITLE_SITE }}.{% endblocktrans %}',
-            player_logo_alt = '{{ TITLE_SITE }}';
-            player_logo_url = '{{ request.build_absolute_uri }}';
+            player_logo_alt = '{{ TITLE_SITE }}',
+            player_logo_url = '{{ request.build_absolute_uri }}',
+            pod_video_url = player_logo_url.split( '/' );
+
+        pod_video_url.pop( );
+        player_logo_url = pod_video_url.join( '/' );
     {% else %}
         var player_logo_img = '';
     {% endif %}

--- a/pod_project/pods/templates/videos/extraheadplayer.html
+++ b/pod_project/pods/templates/videos/extraheadplayer.html
@@ -80,14 +80,19 @@ voir http://www.gnu.org/licenses/
         var overview = '';
     {% endif %}
     {% if LOGO_PLAYER != '' %}
+        {% if request.GET.is_iframe %}
         var player_logo_img = '{% static LOGO_PLAYER %}',
             player_logo_title = '{% blocktrans %}Access this content on “{{ TITLE_SITE }}” in a new window / tab.{% endblocktrans %}',
             player_logo_alt = '{{ TITLE_SITE }}',
             player_logo_url = '{{ request.build_absolute_uri }}',
             pod_video_url = player_logo_url.split( '/' );
-
         pod_video_url.pop( );
         player_logo_url = pod_video_url.join( '/' );
+        {% else %}
+        var player_logo_img = '{% static LOGO_PLAYER %}',
+            player_logo_alt = '{{ TITLE_SITE }}',
+            player_logo_url = '',
+        {% endif %}
     {% else %}
         var player_logo_img = '';
     {% endif %}

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-05 15:10+0200\n"
-"PO-Revision-Date: 2016-10-05 19:26+0200\n"
+"PO-Revision-Date: 2016-10-12 16:03+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: ESUP POD <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -2293,8 +2293,8 @@ msgstr "Supprimer l'enrichissement"
 
 #: pods/templates/videos/extraheadplayer.html:84
 #, python-format
-msgid "Click to reach this content on %(TITLE_SITE)s."
-msgstr "Cliquez pour accéder à ce contenu sur %(TITLE_SITE)s."
+msgid "Access this content on “%(TITLE_SITE)s” in a new window / tab."
+msgstr "Accéder à ce contenu sur « %(TITLE_SITE)s » dans une nouvelle fenêtre / un nouvel onglet."
 
 #: pods/templates/videos/my_videos.html:65
 msgid ""


### PR DESCRIPTION
- Solves a bug introduced in [PR#133](https://github.com/EsupPortail/pod/pull/133): link needs a « target=_blank » attribute to work when content is embedded;
- the logo isn't a link anymore when the player is inside a Pod video page (not embedded).

