### PR TITLE
Feature: pagination container in list templates

### DIFF
--- a/pod_project/core/theme/LILLE1/assets/css/pod.css
+++ b/pod_project/core/theme/LILLE1/assets/css/pod.css
@@ -665,6 +665,10 @@ ul li.vjs-menu-title.vjs-disp-menu-title:hover {
   font-size: .9em;
   line-height: 1.1;
 }
+.pager li > a,
+.pager li > span {
+  border-radius: 0;
+}
 .pagination > .active > a,
 .pagination > .active > span,
 .pagination > .active > a:hover,

--- a/pod_project/core/theme/LILLE1/less/includes/_pod.less
+++ b/pod_project/core/theme/LILLE1/less/includes/_pod.less
@@ -794,6 +794,14 @@ ul li.vjs-menu-title.vjs-disp-menu-title:hover {
     }
 }
 
+.pager li {
+
+    & > a,
+    & > span {
+        border-radius: 0;
+    }
+}
+
 .pagination > .active {
 
     & > a,

--- a/pod_project/pods/templates/channels/channels_list.html
+++ b/pod_project/pods/templates/channels/channels_list.html
@@ -42,4 +42,6 @@ voir http://www.gnu.org/licenses/
 	</div>
 {%endfor%}
 </div>
-{% block pagination %} {% pagination channels %}{% endblock %}
+<div id="pager" class="text-center">
+    {% block pagination %} {% pagination channels %}{% endblock %}
+</div>

--- a/pod_project/pods/templates/channels/channels_list.html
+++ b/pod_project/pods/templates/channels/channels_list.html
@@ -42,6 +42,6 @@ voir http://www.gnu.org/licenses/
 	</div>
 {%endfor%}
 </div>
-<div id="pager" class="text-center">
+<div class="pager">
     {% block pagination %} {% pagination channels %}{% endblock %}
 </div>

--- a/pod_project/pods/templates/disciplines/disciplines_list.html
+++ b/pod_project/pods/templates/disciplines/disciplines_list.html
@@ -37,6 +37,6 @@ voir http://www.gnu.org/licenses/
 	</div>
 {%endfor%}
 </div>
-<div id="pager" class="text-center">
+<div class="pager">
     {% block pagination %} {% pagination disciplines %}{% endblock %}
 </div>

--- a/pod_project/pods/templates/disciplines/disciplines_list.html
+++ b/pod_project/pods/templates/disciplines/disciplines_list.html
@@ -37,4 +37,6 @@ voir http://www.gnu.org/licenses/
 	</div>
 {%endfor%}
 </div>
-{% block pagination %} {% pagination disciplines %}{% endblock %}
+<div id="pager" class="text-center">
+    {% block pagination %} {% pagination disciplines %}{% endblock %}
+</div>

--- a/pod_project/pods/templates/owners/owners_list.html
+++ b/pod_project/pods/templates/owners/owners_list.html
@@ -41,7 +41,7 @@ voir http://www.gnu.org/licenses/
 	</div>
 {%endfor%}
 </div>
-<div id="pager" class="text-center">
+<div class="pager">
     {% block pagination %} {% pagination owners %}{% endblock %}
 </div>
 

--- a/pod_project/pods/templates/owners/owners_list.html
+++ b/pod_project/pods/templates/owners/owners_list.html
@@ -41,5 +41,7 @@ voir http://www.gnu.org/licenses/
 	</div>
 {%endfor%}
 </div>
-{% block pagination %} {% pagination owners %}{% endblock %}
+<div id="pager" class="text-center">
+    {% block pagination %} {% pagination owners %}{% endblock %}
+</div>
 

--- a/pod_project/pods/templates/search/search_video.html
+++ b/pod_project/pods/templates/search/search_video.html
@@ -127,7 +127,7 @@ voir http://www.gnu.org/licenses/
                 {% endwith %}
             {% endfor %}
             </div>
-            <div id="pager" class="text-center">
+            <div class="pager">
                 {% block pagination %}{% pagination search_pagination %}{% endblock %}
             </div>
         {% else %}

--- a/pod_project/pods/templates/types/types_list.html
+++ b/pod_project/pods/templates/types/types_list.html
@@ -37,7 +37,7 @@ voir http://www.gnu.org/licenses/
 	</div>
 {%endfor%}
 </div>
-<div id="pager" class="text-center">
+<div class="pager">
     {% block pagination %} {% pagination types %}{% endblock %}
 </div>
 

--- a/pod_project/pods/templates/types/types_list.html
+++ b/pod_project/pods/templates/types/types_list.html
@@ -37,5 +37,7 @@ voir http://www.gnu.org/licenses/
 	</div>
 {%endfor%}
 </div>
-{% block pagination %} {% pagination types %}{% endblock %}
+<div id="pager" class="text-center">
+    {% block pagination %} {% pagination types %}{% endblock %}
+</div>
 

--- a/pod_project/pods/templates/videos/videos_list.html
+++ b/pod_project/pods/templates/videos/videos_list.html
@@ -114,6 +114,6 @@ voir http://www.gnu.org/licenses/
     {% endfor %}
 </div>
 
-<div id="pager" class="text-center">
+<div class="pager">
     {% block pagination %} {% pagination videos %} {% endblock %}
 </div>


### PR DESCRIPTION
Adds the pagination container to channels / disciplines / owners / types list templates to center the pagination links (as in videos list), and moves from id to class to use BS pager class.

<img width="540" alt="capture d ecran 2016-10-12 a 19 08 28" src="https://cloud.githubusercontent.com/assets/10742818/19320039/ec5168cc-90af-11e6-9a52-2e52cf3a5ae9.png">
