### PR TITLE
Feature: « RemovedInDjango19Warning » fix (get_current_site import)

### DIFF
--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -34,7 +34,7 @@ from datetime import datetime
 from django.conf import settings
 from django.dispatch import receiver
 from django.db.models.signals import post_save, pre_save
-from django.contrib.sites.models import get_current_site
+from django.contrib.sites.shortcuts import get_current_site
 from elasticsearch import Elasticsearch
 # django-taggit
 from taggit.managers import TaggableManager, _TaggableManager, TaggableRel

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -45,7 +45,7 @@ from datetime import datetime, date
 from django.utils import formats
 from django.utils.http import urlquote
 from django.core.mail import EmailMultiAlternatives
-from django.contrib.sites.models import get_current_site
+from django.contrib.sites.shortcuts import get_current_site
 
 import simplejson as json
 


### PR DESCRIPTION
Fixes the « Please import get_current_site from django.contrib.sites.shortcuts. » RemovedInDjango19Warning.

