### PR TITLE
Dotmobo/feature media guard

### DIFF
--- a/pod_project/core/models.py
+++ b/pod_project/core/models.py
@@ -137,12 +137,12 @@ def create_user_profile(sender, instance, created, **kwargs):
             print msg
 
 
-def get_media_guard(login):
+def get_media_guard(login, pod_id):
     """ Get the media guard hash """
     MEDIA_GUARD = getattr(settings, 'MEDIA_GUARD', False)
     MEDIA_GUARD_SALT = getattr(settings, 'MEDIA_GUARD_SALT', None)
-    if MEDIA_GUARD and MEDIA_GUARD_SALT and login:
-        return hashlib.sha256(MEDIA_GUARD_SALT + login).hexdigest()
+    if MEDIA_GUARD and MEDIA_GUARD_SALT and login and pod_id:
+        return hashlib.sha256(MEDIA_GUARD_SALT + login + str(pod_id)).hexdigest()
     else:
         return ""
 
@@ -151,7 +151,7 @@ def get_storage_path(instance, filename):
     """ Get the storage path. Instance needs to implement owner """
     fname, dot, extension = filename.rpartition('.')
     username = instance.owner.username
-    media_guard_hash = get_media_guard(username)
+    media_guard_hash = get_media_guard(username, instance.id)
     try:
         fname.index("/")
         return os.path.join(VIDEOS_DIR, username, media_guard_hash, '%s/%s.%s' % (os.path.dirname(fname), slugify(os.path.basename(fname)), extension))

--- a/pod_project/core/models.py
+++ b/pod_project/core/models.py
@@ -137,11 +137,11 @@ def create_user_profile(sender, instance, created, **kwargs):
             print msg
 
 
-def get_media_guard(login, pod_id):
+def get_media_guard(login, pod_id=0):
     """ Get the media guard hash """
     MEDIA_GUARD = getattr(settings, 'MEDIA_GUARD', False)
     MEDIA_GUARD_SALT = getattr(settings, 'MEDIA_GUARD_SALT', None)
-    if MEDIA_GUARD and MEDIA_GUARD_SALT and login and pod_id:
+    if MEDIA_GUARD and MEDIA_GUARD_SALT and login:
         return hashlib.sha256(MEDIA_GUARD_SALT + login + str(pod_id)).hexdigest()
     else:
         return ""
@@ -151,7 +151,8 @@ def get_storage_path(instance, filename):
     """ Get the storage path. Instance needs to implement owner """
     fname, dot, extension = filename.rpartition('.')
     username = instance.owner.username
-    media_guard_hash = get_media_guard(username, instance.id)
+    pod_id = instance.id if instance.id else 0
+    media_guard_hash = get_media_guard(username, pod_id)
     try:
         fname.index("/")
         return os.path.join(VIDEOS_DIR, username, media_guard_hash, '%s/%s.%s' % (os.path.dirname(fname), slugify(os.path.basename(fname)), extension))

--- a/pod_project/core/tests/test_install.py
+++ b/pod_project/core/tests/test_install.py
@@ -37,7 +37,7 @@ from core.utils import encode_video
 import os
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -62,7 +62,7 @@ class CasTestView(TestCase):
             print "not cas server used USE_CAS is set to False"
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -121,7 +121,7 @@ class LdapTestView(TestCase):
             print "not cas server used or not ldap server used USE_LDAP_TO_POPULATE_USER is set to False or settings.AUTH_LDAP_UID_TEST is none"
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -143,7 +143,7 @@ class EsTestView(TestCase):
         print "\n   --->  test_es of EsTestView : OK ! \n info : \n %s \n" % r.data
 
 @override_settings(
-    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'), 
+    MEDIA_ROOT = os.path.join(settings.BASE_DIR, 'media'),
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -157,7 +157,8 @@ class EncodingFileTestView(TestCase):
     def setUp(self):
         remi = User.objects.create(username="remi")
         other_type = Type.objects.get(id=1)
-        file_path = os.path.join(settings.MEDIA_ROOT, 'videos', remi.username, 'test.mp4')
+        media_guard_hash = get_media_guard("remi", 1)
+        file_path = os.path.join(settings.MEDIA_ROOT, 'videos', remi.username, media_guard_hash, 'test.mp4')
         if not os.path.exists(file_path):
             url = "http://pod.univ-lille1.fr/media/pod.mp4"
             print "Download video file from %s" %url
@@ -178,7 +179,7 @@ class EncodingFileTestView(TestCase):
             print "File already exist"
             pod = Pod.objects.create(
                 type=other_type, title="Video", owner=remi, video="-", to_encode=False)
-            pod.video.name = os.path.join('videos', remi.username, 'test.mp4')
+            pod.video.name = os.path.join('videos', remi.username, media_guard_hash, 'test.mp4')
             pod.save()
         print "\n --->  SetUp of EncodingFileTestView : OK !"
 

--- a/pod_project/core/tests/test_models.py
+++ b/pod_project/core/tests/test_models.py
@@ -21,7 +21,7 @@ voir http://www.gnu.org/licenses/
 """
 from filer.models.imagemodels import Image
 from django.core.files import File
-from core.models import FileBrowse, get_storage_path, EncodingType
+from core.models import FileBrowse, get_storage_path, EncodingType, get_media_guard
 from pods.models import Pod, Type, EncodingPods
 from django.contrib.auth.models import User, Group
 from django.test import TestCase, override_settings
@@ -86,12 +86,14 @@ class TestStoragePath(TestCase):
             encodingFile="video_2_240.mp4"
         )
 
+    @override_settings(MEDIA_GUARD=False)
     def test_get_storage_path_video(self):
         storage_path_1 = get_storage_path(self.video1, self.path1)
         self.assertEquals(storage_path_1, "videos/remi/"+self.path1)
         storage_path_2 = get_storage_path(self.video2, self.path2)
         self.assertEquals(storage_path_2, "videos/remi/"+self.path2)
 
+    @override_settings(MEDIA_GUARD=False)
     def test_get_storage_path_encodingpods(self):
         storage_path_1 = get_storage_path(self.encodingpods1,
                                           self.path1)
@@ -99,3 +101,34 @@ class TestStoragePath(TestCase):
         storage_path_2 = get_storage_path(self.encodingpods2,
                                           self.path2)
         self.assertEquals(storage_path_2, "videos/remi/"+self.path2)
+
+    @override_settings(MEDIA_GUARD=False, MEDIA_GUARD_SALT="S3CR3T")
+    def test_get_media_guard_disabled(self):
+        media_guard_hash = get_media_guard("remi")
+        self.assertEqual(media_guard_hash, "")
+
+    @override_settings(MEDIA_GUARD=True, MEDIA_GUARD_SALT="")
+    def test_get_media_guard_empty(self):
+        media_guard_hash = get_media_guard("remi")
+        self.assertEqual(media_guard_hash, "")
+
+    @override_settings(MEDIA_GUARD=True, MEDIA_GUARD_SALT="S3CR3T")
+    def test_get_media_guard(self):
+        media_guard_hash = get_media_guard("remi")
+        self.assertEqual(media_guard_hash, "3aab29e4d16b25734b3ab6351dc0b06620b6983fe1328840dfccda8f2d39e91b")
+
+    @override_settings(MEDIA_GUARD=True, MEDIA_GUARD_SALT="S3CR3T")
+    def test_get_storage_path_video_with_media_guard(self):
+        storage_path_1 = get_storage_path(self.video1, self.path1)
+        self.assertEquals(storage_path_1, "videos/remi/3aab29e4d16b25734b3ab6351dc0b06620b6983fe1328840dfccda8f2d39e91b/"+self.path1)
+        storage_path_2 = get_storage_path(self.video2, self.path2)
+        self.assertEquals(storage_path_2, "videos/remi/3aab29e4d16b25734b3ab6351dc0b06620b6983fe1328840dfccda8f2d39e91b/"+self.path2)
+
+    @override_settings(MEDIA_GUARD=True, MEDIA_GUARD_SALT="S3CR3T")
+    def test_get_storage_path_encodingpods_with_media_guard(self):
+        storage_path_1 = get_storage_path(self.encodingpods1,
+                                          self.path1)
+        self.assertEquals(storage_path_1, "videos/remi/3aab29e4d16b25734b3ab6351dc0b06620b6983fe1328840dfccda8f2d39e91b/"+self.path1)
+        storage_path_2 = get_storage_path(self.encodingpods2,
+                                          self.path2)
+        self.assertEquals(storage_path_2, "videos/remi/3aab29e4d16b25734b3ab6351dc0b06620b6983fe1328840dfccda8f2d39e91b/"+self.path2)

--- a/pod_project/core/tests/test_models.py
+++ b/pod_project/core/tests/test_models.py
@@ -104,31 +104,31 @@ class TestStoragePath(TestCase):
 
     @override_settings(MEDIA_GUARD=False, MEDIA_GUARD_SALT="S3CR3T")
     def test_get_media_guard_disabled(self):
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", self.video1.id)
         self.assertEqual(media_guard_hash, "")
 
     @override_settings(MEDIA_GUARD=True, MEDIA_GUARD_SALT="")
     def test_get_media_guard_empty(self):
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", self.video1.id)
         self.assertEqual(media_guard_hash, "")
 
     @override_settings(MEDIA_GUARD=True, MEDIA_GUARD_SALT="S3CR3T")
     def test_get_media_guard(self):
-        media_guard_hash = get_media_guard("remi")
-        self.assertEqual(media_guard_hash, "3aab29e4d16b25734b3ab6351dc0b06620b6983fe1328840dfccda8f2d39e91b")
+        media_guard_hash = get_media_guard("remi", self.video1.id)
+        self.assertEqual(media_guard_hash, "df880ec636fe3a9dd39a33609dc44635a7c19d7b7b46deba33c281cf2edf0ca5")
 
     @override_settings(MEDIA_GUARD=True, MEDIA_GUARD_SALT="S3CR3T")
     def test_get_storage_path_video_with_media_guard(self):
         storage_path_1 = get_storage_path(self.video1, self.path1)
-        self.assertEquals(storage_path_1, "videos/remi/3aab29e4d16b25734b3ab6351dc0b06620b6983fe1328840dfccda8f2d39e91b/"+self.path1)
+        self.assertEquals(storage_path_1, "videos/remi/df880ec636fe3a9dd39a33609dc44635a7c19d7b7b46deba33c281cf2edf0ca5/"+self.path1)
         storage_path_2 = get_storage_path(self.video2, self.path2)
-        self.assertEquals(storage_path_2, "videos/remi/3aab29e4d16b25734b3ab6351dc0b06620b6983fe1328840dfccda8f2d39e91b/"+self.path2)
+        self.assertEquals(storage_path_2, "videos/remi/a1b11067d34f07639d40f411bbf70c2a601a464799699fb1af370f7bf24cb79c/"+self.path2)
 
     @override_settings(MEDIA_GUARD=True, MEDIA_GUARD_SALT="S3CR3T")
     def test_get_storage_path_encodingpods_with_media_guard(self):
         storage_path_1 = get_storage_path(self.encodingpods1,
                                           self.path1)
-        self.assertEquals(storage_path_1, "videos/remi/3aab29e4d16b25734b3ab6351dc0b06620b6983fe1328840dfccda8f2d39e91b/"+self.path1)
+        self.assertEquals(storage_path_1, "videos/remi/df880ec636fe3a9dd39a33609dc44635a7c19d7b7b46deba33c281cf2edf0ca5/"+self.path1)
         storage_path_2 = get_storage_path(self.encodingpods2,
                                           self.path2)
-        self.assertEquals(storage_path_2, "videos/remi/3aab29e4d16b25734b3ab6351dc0b06620b6983fe1328840dfccda8f2d39e91b/"+self.path2)
+        self.assertEquals(storage_path_2, "videos/remi/a1b11067d34f07639d40f411bbf70c2a601a464799699fb1af370f7bf24cb79c/"+self.path2)

--- a/pod_project/core/utils.py
+++ b/pod_project/core/utils.py
@@ -31,7 +31,7 @@ import logging
 import traceback
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
-from core.models import EncodingType
+from core.models import EncodingType, get_media_guard
 from pods.models import EncodingPods
 from pods.models import Pod
 
@@ -221,11 +221,12 @@ def encode_video(video_to_encode):
         # VIDEO/AUDIO FOLDER
         if DEBUG:
             print "VIDEO/AUDIO FOLDER"
+        media_guard_hash = get_media_guard(video_to_encode.owner.username)
         if not(
             os.access(
-                os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video_to_encode.owner.username, "%s" % video_to_encode.id), os.F_OK)):
+                os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video_to_encode.owner.username, media_guard_hash, "%s" % video_to_encode.id), os.F_OK)):
             os.makedirs(os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR,
-                                     video_to_encode.owner.username, "%s" % video_to_encode.id))
+                                     video_to_encode.owner.username, media_guard_hash, "%s" % video_to_encode.id))
         if DEBUG:
             print "END VIDEO/AUDIO FOLDER"
         # FILER FOLDER
@@ -258,9 +259,10 @@ def encode_video(video_to_encode):
                     pass
                 if in_height >= encod_video.output_height or encod_video == list_encod_video.first():
                     video = Pod.objects.get(id=VIDEO_ID)
-                    videofilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, "%s" % video.id,
+                    media_guard_hash = get_media_guard(video.owner.username)
+                    videofilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                                                  "video_%s_%s.mp4" % (video.id, encod_video.output_height))
-                    videourl = os.path.join(VIDEOS_DIR, video.owner.username, "%s" % video.id,
+                    videourl = os.path.join(VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                                             "video_%s_%s.mp4" % (video.id, encod_video.output_height))
                     encode_mp4(VIDEO_ID, in_width, in_height, bufsize,
                                in_audio_rate, encod_video, videofilename, videourl)
@@ -270,9 +272,10 @@ def encode_video(video_to_encode):
             list_encod_audio = EncodingType.objects.filter(mediatype='audio')
             for encod_audio in list_encod_audio:
                 video = Pod.objects.get(id=VIDEO_ID)
-                audiofilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, "%s" % video.id,
+                media_guard_hash = get_media_guard(video.owner.username)
+                audiofilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                                              "audio_%s_%s.mp3" % (video.id, encod_audio.output_height))
-                audiourl = os.path.join(VIDEOS_DIR, video.owner.username, "%s" % video.id,
+                audiourl = os.path.join(VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                                         "audio_%s_%s.mp3" % (video.id, encod_audio.output_height))
                 encode_mp3(
                     VIDEO_ID, audiofilename, audiourl, encod_audio, in_audio_rate)
@@ -345,6 +348,7 @@ def add_thumbnails(video_id, in_w, in_h, folder):
     video.encoding_status = "ADD THUMBNAILS"
     video.save()
     tempfile = NamedTemporaryFile()
+    media_guard_hash = get_media_guard(video.owner.username)
     scale = get_scale(in_w, in_h, DEFAULT_THUMBNAIL_OUT_SIZE_HEIGHT)
     thumbnails = int(video.duration / 3)
     com = ADD_THUMBNAILS_CMD % {
@@ -366,7 +370,7 @@ def add_thumbnails(video_id, in_w, in_h, folder):
     output += 80 * "~"
 
     f = open(os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR,
-                          video.owner.username, "%s" % video.id, "encode.log"), 'w')
+                          video.owner.username, media_guard_hash, "%s" % video.id, "encode.log"), 'w')
     f.write(output)
     output = ""
     f.close()
@@ -409,11 +413,11 @@ def add_overview(video_id, in_w, in_h, frames):
     video = Pod.objects.get(id=video_id)
     thumbnails = int(frames / 100)
     scale = get_scale(in_w, in_h, DEFAULT_OVERVIEW_OUT_SIZE_HEIGHT)
-
+    media_guard_hash = get_media_guard(video.owner.username)
     overviewfilename = os.path.join(
-        settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, "%s" % video.id, "overview.jpg")
+        settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id, "overview.jpg")
     overviewurl = os.path.join(
-        VIDEOS_DIR, video.owner.username, "%s" % video.id, "overview.jpg")
+        VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id, "overview.jpg")
 
     com = ADD_OVERVIEW_CMD % {
         'ffmpeg': FFMPEG,
@@ -454,7 +458,7 @@ def add_overview(video_id, in_w, in_h, frames):
             video.save()
 
     f = open(os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR,
-                          video.owner.username, "%s" % video.id, "encode.log"), 'a+b')
+                          video.owner.username, media_guard_hash, "%s" % video.id, "encode.log"), 'a+b')
     f.write(output)
     output = ""
     f.close()
@@ -489,6 +493,7 @@ def encode_mp4(video_id, in_w, in_h, bufsize, in_ar, encod_video, videofilename,
     ffmpegresult = commands.getoutput(com)
     video = None
     video = Pod.objects.get(id=video_id)
+    media_guard_hash = get_media_guard(video.owner.username)
     addInfoVideo(video, "\n END ENCOD_VIDEO MP4 %s %s" %
                  (encod_video.output_height, time.ctime()))
 
@@ -522,7 +527,7 @@ def encode_mp4(video_id, in_w, in_h, bufsize, in_ar, encod_video, videofilename,
             video.save()
 
     f = open(os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR,
-                          video.owner.username, "%s" % video.id, "encode.log"), 'a+b')
+                          video.owner.username, media_guard_hash, "%s" % video.id, "encode.log"), 'a+b')
     f.write(output)
     output = ""
     f.close()
@@ -536,9 +541,10 @@ def encode_webm(video_id, videofilename, encod_video, bufsize):
     addInfoVideo(video, "\nSTART ENCOD_VIDEO WEBM %s %s" %
                  (encod_video.output_height, time.ctime()))
     video.save()
-    webmfilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, "%s" % video.id,
+    media_guard_hash = get_media_guard(video.owner.username)
+    webmfilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                                 "video_%s_%s.webm" % (video.id, encod_video.output_height))
-    webmurl = os.path.join(VIDEOS_DIR, video.owner.username, "%s" % video.id,
+    webmurl = os.path.join(VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                            "video_%s_%s.webm" % (video.id, encod_video.output_height))
 
     com = ENCODE_WEBM_CMD % {
@@ -587,7 +593,7 @@ def encode_webm(video_id, videofilename, encod_video, bufsize):
             video.save()
 
     f = open(os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR,
-                          video.owner.username, "%s" % video.id, "encode.log"), 'a+b')
+                          video.owner.username, media_guard_hash, "%s" % video.id, "encode.log"), 'a+b')
     f.write(output)
     output = ""
     f.close()
@@ -621,6 +627,7 @@ def encode_mp3(video_id, audiofilename, audiourl, encod_audio, in_ar):
     video = None
     video = Pod.objects.get(id=video_id)
     addInfoVideo(video, "\nEND ENCOD_VIDEO MP3 %s" % (time.ctime()))
+    media_guard_hash = get_media_guard(video.owner.username)
 
     if os.access(audiofilename, os.F_OK):  # outfile exists
         # There was a error cause the outfile size is zero
@@ -642,7 +649,7 @@ def encode_mp3(video_id, audiofilename, audiourl, encod_audio, in_ar):
             ep.save()
 
     f = open(os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR,
-                          video.owner.username, "%s" % video.id, "encode.log"), 'w')
+                          video.owner.username, media_guard_hash, "%s" % video.id, "encode.log"), 'w')
     f.write(output)
     output = ""
     f.close()
@@ -656,9 +663,10 @@ def encode_wav(video_id, audiofilename, in_ar, encod_audio):
     video.encoding_status = "ENCODING WAV"
     addInfoVideo(video, "\nStart ENCOD_VIDEO WAV %s" % (time.ctime()))
     video.save()
-    wavfilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, "%s" % video.id,
+    media_guard_hash = get_media_guard(video.owner.username)
+    wavfilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                                "audio_%s_%s.wav" % (video.id, encod_audio.output_height))
-    wavurl = os.path.join(VIDEOS_DIR, video.owner.username, "%s" % video.id,
+    wavurl = os.path.join(VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                           "audio_%s_%s.wav" % (video.id, encod_audio.output_height))
     com = ENCODE_WAV_CMD % {
         'ffmpeg': FFMPEG,
@@ -701,7 +709,7 @@ def encode_wav(video_id, audiofilename, in_ar, encod_audio):
             ep.save()
 
     f = open(os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR,
-                          video.owner.username, "%s" % video.id, "encode.log"), 'a+b')
+                          video.owner.username, media_guard_hash, "%s" % video.id, "encode.log"), 'a+b')
     f.write(output)
     output = ""
     f.close()

--- a/pod_project/core/utils.py
+++ b/pod_project/core/utils.py
@@ -221,7 +221,7 @@ def encode_video(video_to_encode):
         # VIDEO/AUDIO FOLDER
         if DEBUG:
             print "VIDEO/AUDIO FOLDER"
-        media_guard_hash = get_media_guard(video_to_encode.owner.username)
+        media_guard_hash = get_media_guard(video_to_encode.owner.username, video_to_encode.id)
         if not(
             os.access(
                 os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video_to_encode.owner.username, media_guard_hash, "%s" % video_to_encode.id), os.F_OK)):
@@ -259,7 +259,7 @@ def encode_video(video_to_encode):
                     pass
                 if in_height >= encod_video.output_height or encod_video == list_encod_video.first():
                     video = Pod.objects.get(id=VIDEO_ID)
-                    media_guard_hash = get_media_guard(video.owner.username)
+                    media_guard_hash = get_media_guard(video.owner.username, video.id)
                     videofilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                                                  "video_%s_%s.mp4" % (video.id, encod_video.output_height))
                     videourl = os.path.join(VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
@@ -272,7 +272,7 @@ def encode_video(video_to_encode):
             list_encod_audio = EncodingType.objects.filter(mediatype='audio')
             for encod_audio in list_encod_audio:
                 video = Pod.objects.get(id=VIDEO_ID)
-                media_guard_hash = get_media_guard(video.owner.username)
+                media_guard_hash = get_media_guard(video.owner.username, video.id)
                 audiofilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                                              "audio_%s_%s.mp3" % (video.id, encod_audio.output_height))
                 audiourl = os.path.join(VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
@@ -348,7 +348,7 @@ def add_thumbnails(video_id, in_w, in_h, folder):
     video.encoding_status = "ADD THUMBNAILS"
     video.save()
     tempfile = NamedTemporaryFile()
-    media_guard_hash = get_media_guard(video.owner.username)
+    media_guard_hash = get_media_guard(video.owner.username, video.id)
     scale = get_scale(in_w, in_h, DEFAULT_THUMBNAIL_OUT_SIZE_HEIGHT)
     thumbnails = int(video.duration / 3)
     com = ADD_THUMBNAILS_CMD % {
@@ -413,7 +413,7 @@ def add_overview(video_id, in_w, in_h, frames):
     video = Pod.objects.get(id=video_id)
     thumbnails = int(frames / 100)
     scale = get_scale(in_w, in_h, DEFAULT_OVERVIEW_OUT_SIZE_HEIGHT)
-    media_guard_hash = get_media_guard(video.owner.username)
+    media_guard_hash = get_media_guard(video.owner.username, video.id)
     overviewfilename = os.path.join(
         settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id, "overview.jpg")
     overviewurl = os.path.join(
@@ -493,7 +493,7 @@ def encode_mp4(video_id, in_w, in_h, bufsize, in_ar, encod_video, videofilename,
     ffmpegresult = commands.getoutput(com)
     video = None
     video = Pod.objects.get(id=video_id)
-    media_guard_hash = get_media_guard(video.owner.username)
+    media_guard_hash = get_media_guard(video.owner.username, video.id)
     addInfoVideo(video, "\n END ENCOD_VIDEO MP4 %s %s" %
                  (encod_video.output_height, time.ctime()))
 
@@ -541,7 +541,7 @@ def encode_webm(video_id, videofilename, encod_video, bufsize):
     addInfoVideo(video, "\nSTART ENCOD_VIDEO WEBM %s %s" %
                  (encod_video.output_height, time.ctime()))
     video.save()
-    media_guard_hash = get_media_guard(video.owner.username)
+    media_guard_hash = get_media_guard(video.owner.username, video.id)
     webmfilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                                 "video_%s_%s.webm" % (video.id, encod_video.output_height))
     webmurl = os.path.join(VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
@@ -627,7 +627,7 @@ def encode_mp3(video_id, audiofilename, audiourl, encod_audio, in_ar):
     video = None
     video = Pod.objects.get(id=video_id)
     addInfoVideo(video, "\nEND ENCOD_VIDEO MP3 %s" % (time.ctime()))
-    media_guard_hash = get_media_guard(video.owner.username)
+    media_guard_hash = get_media_guard(video.owner.username, video.id)
 
     if os.access(audiofilename, os.F_OK):  # outfile exists
         # There was a error cause the outfile size is zero
@@ -663,7 +663,7 @@ def encode_wav(video_id, audiofilename, in_ar, encod_audio):
     video.encoding_status = "ENCODING WAV"
     addInfoVideo(video, "\nStart ENCOD_VIDEO WAV %s" % (time.ctime()))
     video.save()
-    media_guard_hash = get_media_guard(video.owner.username)
+    media_guard_hash = get_media_guard(video.owner.username, video.id)
     wavfilename = os.path.join(settings.MEDIA_ROOT, VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,
                                "audio_%s_%s.wav" % (video.id, encod_audio.output_height))
     wavurl = os.path.join(VIDEOS_DIR, video.owner.username, media_guard_hash, "%s" % video.id,

--- a/pod_project/pod_project/settings-sample.py
+++ b/pod_project/pod_project/settings-sample.py
@@ -390,3 +390,7 @@ RECORDER_SALT = "abcdefgh"
 # Signalement des vidéos
 SHOW_REPORT = True
 REPORT_VIDEO_MAIL_TO = ['alert@univ.fr']
+
+# Protection des médias
+MEDIA_GUARD = False
+MEDIA_GUARD_SALT = "S3CR3T"

--- a/pod_project/pods/tests/tests_delete_video.py
+++ b/pod_project/pods/tests/tests_delete_video.py
@@ -68,16 +68,17 @@ class Video_deleteTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
-                                 date_added=datetime.today(), owner=user, date_evt=datetime.today(), video="videos/remi/test.mp4", overview=u'videos/remi/1/overview.jpg',
+                                 date_added=datetime.today(), owner=user, date_evt=datetime.today(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
                                  to_encode=False)
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.mp4"), encodingFormat="video/mp4")
         ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
         pod.channel.add(c)
         pod.theme.add(t)
         pod.save()

--- a/pod_project/pods/tests/tests_models.py
+++ b/pod_project/pods/tests/tests_models.py
@@ -345,10 +345,11 @@ class VideoTestCase(TestCase):
     def setUp(self):
         remi = User.objects.create_user("Remi")
         other_type = Type.objects.get(id=1)
+        self.media_guard_hash = get_media_guard("remi", 1)
         Pod.objects.create(
             type=other_type, title="Video1", owner=remi, video="", to_encode=False)
         Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
-                           date_added=datetime.today(), owner=remi, date_evt=datetime.today(), video="/media/videos/remi/test.mp4", allow_downloading=True, view_count=2, description="fl",
+                           date_added=datetime.today(), owner=remi, date_evt=datetime.today(), video=os.path.join("media", "videos", "remi", self.media_guard_hash, "test.mp4"), allow_downloading=True, view_count=2, description="fl",
                            overview="blabla.jpg", is_draft=False, duration=3, infoVideo="videotest", to_encode=False)
         print (" --->  SetUp of VideoTestCase : OK !")
 
@@ -390,7 +391,7 @@ class VideoTestCase(TestCase):
 
     def test_Video_many_attributs(self):
         pod = Pod.objects.get(id=2)
-        self.assertEqual(pod.video.name, u'/media/videos/remi/test.mp4')
+        self.assertEqual(pod.video.name, os.path.join('media', 'videos', 'remi', self.media_guard_hash, 'test.mp4'))
         self.assertEqual(pod.allow_downloading, True)
         self.assertEqual(pod.description, 'fl')
         self.assertEqual(pod.overview.name, "blabla.jpg")

--- a/pod_project/pods/tests/tests_views.py
+++ b/pod_project/pods/tests/tests_views.py
@@ -928,19 +928,19 @@ class VideoTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         type1 = Type.objects.create(title="type1")
-        media_guard_hash1 = get_media_guard("remi", 1)
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=type1, title=u'Bunny',
-                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash1, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash1, '1', 'overview.jpg'),
+                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=False, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
                                  to_encode=False)
 
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile=os.path.join('videos', 'remi', media_guard_hash1, '1', 'video_1_240.mp4'), encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join('videos', 'remi', media_guard_hash, '1', 'video_1_240.mp4'), encodingFormat="video/mp4")
 
         ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash1, "1", "video_1_240.webm"), encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
 
         pod.channel.add(c)
         pod.theme.add(t)

--- a/pod_project/pods/tests/tests_views.py
+++ b/pod_project/pods/tests/tests_views.py
@@ -68,7 +68,7 @@ class ChannelsTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=Channel.objects.get(id=1))
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=False,
                                  date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
                                  allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
@@ -204,7 +204,7 @@ class ChannelTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
                                  date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
                                  allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
@@ -377,7 +377,7 @@ class TypesTestView(TestCase):
     def setUp(self):
         remi = User.objects.create_user(username="remi")
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
                                  date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
                                  allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
@@ -426,7 +426,7 @@ class OwnersTestView(TestCase):
     def setUp(self):
         remi = User.objects.create_user(username="Remi", last_name="Lefevbre")
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
                                  date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
                                  allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
@@ -494,7 +494,7 @@ class DisciplinesTestView(TestCase):
         Discipline.objects.create(title="Discipline1")
         other_type = Type.objects.get(id=1)
         d1 = Discipline.objects.create(title="Discipline2")
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
                                  date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
                                  allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
@@ -545,7 +545,7 @@ class Owner_Videos_listTestView(TestCase):
         self.user.set_password('hello')
         self.user.save()
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         i = 1
         while i < 3:
             pod = Pod.objects.create(type=other_type, title="Video" + str(i), encoding_status="b", encoding_in_progress=True,
@@ -602,7 +602,7 @@ class Tags_TestView(TestCase):
     def setUp(self):
         remi = User.objects.create_user(username="remi")
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
                                  date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
                                  allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
@@ -646,7 +646,7 @@ class Video_add_favoriteTestView(TestCase):
         user2.set_password('hello')
         user2.save()
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
                                  date_added=datetime.today().date(), owner=user2, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
                                  allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
@@ -720,7 +720,7 @@ class Video_add_reportTestView(TestCase):
         user2.set_password('hello')
         user2.save()
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
                                  date_added=datetime.today().date(), owner=user2, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
                                  allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
@@ -780,7 +780,7 @@ class Favorites_videos_listTestView(TestCase):
         user2.set_password('hello')
         user2.save()
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         i = 1
         while i < 5:
             pod = Pod.objects.create(type=other_type, title="Video" + str(i), encoding_status="b", encoding_in_progress=True,
@@ -847,7 +847,7 @@ class VideosTestView(TestCase):
         user.set_password('hello')
         user.save()
         type1 = Type.objects.create(title="type1")
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         i = 1
         while i < 5:
             pod = Pod.objects.create(type=type1, title="Video" + str(i), encoding_status="b", encoding_in_progress=True,
@@ -928,7 +928,7 @@ class VideoTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         type1 = Type.objects.create(title="type1")
-        media_guard_hash1 = get_media_guard("remi")
+        media_guard_hash1 = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=type1, title=u'Bunny',
                                  date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash1, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash1, '1', 'overview.jpg'),
                                  allow_downloading=False, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
@@ -1046,7 +1046,7 @@ class Video_edit_testCase(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
                                  date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
@@ -1148,7 +1148,7 @@ class Video_notesTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
                                  date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
@@ -1224,7 +1224,7 @@ class Video_completion_TestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
                                  date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
@@ -1553,7 +1553,7 @@ class Video_chapterTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
                                  date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
@@ -1724,7 +1724,7 @@ class Video_search_videos(TestCase):
         user.save()
 
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
                                  date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="bugs", is_draft=False,
@@ -1823,7 +1823,7 @@ class Video_enrichTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
-        media_guard_hash = get_media_guard("remi")
+        media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
                                  date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,

--- a/pod_project/pods/tests/tests_views.py
+++ b/pod_project/pods/tests/tests_views.py
@@ -68,9 +68,10 @@ class ChannelsTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=Channel.objects.get(id=1))
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=False,
-                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video="videos/remi/test.mp4",
-                                 allow_downloading=True, view_count=2, description="fl", overview="videos/remi/1/overview.jpg", is_draft=False,
+                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
+                                 allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                  duration=3, infoVideo="videotest", to_encode=False)
         EncodingPods.objects.create(
             video=pod, encodingType=EncodingType.objects.get(id=1))
@@ -203,9 +204,10 @@ class ChannelTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
-                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video="videos/remi/test.mp4",
-                                 allow_downloading=True, view_count=2, description="fl", overview="videos/remi/1/overview.jpg", is_draft=False,
+                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
+                                 allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                  duration=3, infoVideo="videotest", to_encode=False)
         pod.save()
         pod.theme.add(t)
@@ -375,16 +377,17 @@ class TypesTestView(TestCase):
     def setUp(self):
         remi = User.objects.create_user(username="remi")
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
-                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video="videos/remi/test.mp4",
-                                 allow_downloading=True, view_count=2, description="fl", overview="videos/remi/1/overview.jpg", is_draft=False,
+                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
+                                 allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                  duration=3, infoVideo="videotest", to_encode=False)
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.mp4"), encodingFormat="video/mp4")
         ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
         pod.save()
         Type.objects.create(title="Type2")
         print(" --->  SetUp of TypesTestView : OK !")
@@ -423,16 +426,17 @@ class OwnersTestView(TestCase):
     def setUp(self):
         remi = User.objects.create_user(username="Remi", last_name="Lefevbre")
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
-                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video="videos/remi/test.mp4",
-                                 allow_downloading=True, view_count=2, description="fl", overview="videos/remi/1/overview.jpg", is_draft=False,
+                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
+                                 allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                  duration=3, infoVideo="videotest", to_encode=False)
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.mp4"), encodingFormat="video/mp4")
         ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
         pod.save()
         print(" --->  SetUp of OwnersTestView : OK !")
 
@@ -490,14 +494,15 @@ class DisciplinesTestView(TestCase):
         Discipline.objects.create(title="Discipline1")
         other_type = Type.objects.get(id=1)
         d1 = Discipline.objects.create(title="Discipline2")
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
-                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video="videos/remi/test.mp4",
-                                 allow_downloading=True, view_count=2, description="fl", overview="videos/remi/1/overview.jpg", is_draft=False,
+                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
+                                 allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                  duration=3, infoVideo="videotest", to_encode=False)
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.mp4"), encodingFormat="video/mp4")
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
         pod.discipline.add(d1)
         pod.save()
         print(" --->  SetUp of DisciplinesTestView : OK !")
@@ -540,11 +545,12 @@ class Owner_Videos_listTestView(TestCase):
         self.user.set_password('hello')
         self.user.save()
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         i = 1
         while i < 3:
             pod = Pod.objects.create(type=other_type, title="Video" + str(i), encoding_status="b", encoding_in_progress=True,
-                                     date_added=datetime.today().date(), owner=self.user, date_evt=datetime.today().date(), video="videos/remi/test.mp4",
-                                     allow_downloading=True, view_count=2, description="fl", overview="videos/remi/1/overview.jpg", is_draft=False,
+                                     date_added=datetime.today().date(), owner=self.user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
+                                     allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                      duration=3, infoVideo="videotest", to_encode=False)
 
             pod.save()
@@ -596,9 +602,10 @@ class Tags_TestView(TestCase):
     def setUp(self):
         remi = User.objects.create_user(username="remi")
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
-                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video="videos/remi/test.mp4",
-                                 allow_downloading=True, view_count=2, description="fl", overview="videos/remi/1/overview.jpg", is_draft=False,
+                                 date_added=datetime.today().date(), owner=remi, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
+                                 allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                  duration=3, infoVideo="videotest", to_encode=False)
         pod.tags.add(u"testtagVideo2")
         pod.tags.add(u"téstàvecâccent")
@@ -639,9 +646,10 @@ class Video_add_favoriteTestView(TestCase):
         user2.set_password('hello')
         user2.save()
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
-                                 date_added=datetime.today().date(), owner=user2, date_evt=datetime.today().date(), video="videos/remi/test.mp4",
-                                 allow_downloading=True, view_count=2, description="fl", overview="videos/remi/1/overview.jpg", is_draft=False,
+                                 date_added=datetime.today().date(), owner=user2, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
+                                 allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                  duration=3, infoVideo="videotest", to_encode=False)
         pod.save()
         print(" --->  SetUp of Video_add_favoriteTestView : OK !")
@@ -712,9 +720,10 @@ class Video_add_reportTestView(TestCase):
         user2.set_password('hello')
         user2.save()
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=True,
-                                 date_added=datetime.today().date(), owner=user2, date_evt=datetime.today().date(), video="videos/remi/test.mp4",
-                                 allow_downloading=True, view_count=2, description="fl", overview="videos/remi/1/overview.jpg", is_draft=False,
+                                 date_added=datetime.today().date(), owner=user2, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
+                                 allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                  duration=3, infoVideo="videotest", to_encode=False)
         pod.save()
         print(" --->  SetUp of Video_add_reportTestView : OK !")
@@ -771,11 +780,12 @@ class Favorites_videos_listTestView(TestCase):
         user2.set_password('hello')
         user2.save()
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         i = 1
         while i < 5:
             pod = Pod.objects.create(type=other_type, title="Video" + str(i), encoding_status="b", encoding_in_progress=True,
-                                     date_added=datetime.today().date(), owner=user2, date_evt=datetime.today().date(), video="videos/remi/test.mp4",
-                                     allow_downloading=True, view_count=2, description="fl", overview="videos/remi/1/overview.jpg", is_draft=False,
+                                     date_added=datetime.today().date(), owner=user2, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
+                                     allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                      duration=3, infoVideo="videotest", to_encode=False)
             pod.save()
             i += 1
@@ -837,18 +847,19 @@ class VideosTestView(TestCase):
         user.set_password('hello')
         user.save()
         type1 = Type.objects.create(title="type1")
+        media_guard_hash = get_media_guard("remi")
         i = 1
         while i < 5:
             pod = Pod.objects.create(type=type1, title="Video" + str(i), encoding_status="b", encoding_in_progress=True,
-                                     date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video="videos/remi/test.mp4",
-                                     allow_downloading=True, view_count=0, description="fl", overview="videos/remi/1/overview.jpg", is_draft=False,
+                                     date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"),
+                                     allow_downloading=True, view_count=0, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                      duration=3, infoVideo="videotest", to_encode=False)
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="/media/videos/remi/1/video_1_240.mp4")
+                id=1), encodingFile=os.path.join("media", "videos", "remi", media_guard_hash, "1", "video_1_240.mp4"))
             ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
             if ENCODE_WEBM:
                 EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                    id=1), encodingFile="/media/videos/remi/1/video_1_240.webm")
+                    id=1), encodingFile=os.path.join("media", "videos", "remi", media_guard_hash, "1", "video_1_240.webm"))
             pod.tags.add("videotests")
             if i % 2:
                 pod.discipline.add(d1)
@@ -917,18 +928,19 @@ class VideoTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         type1 = Type.objects.create(title="type1")
+        media_guard_hash1 = get_media_guard("remi")
         pod = Pod.objects.create(type=type1, title=u'Bunny',
-                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video="videos/remi/test.mp4", overview=u'videos/remi/1/overview.jpg',
+                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash1, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash1, '1', 'overview.jpg'),
                                  allow_downloading=False, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
                                  to_encode=False)
 
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join('videos', 'remi', media_guard_hash1, '1', 'video_1_240.mp4'), encodingFormat="video/mp4")
 
         ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash1, "1", "video_1_240.webm"), encodingFormat="video/webm")
 
         pod.channel.add(c)
         pod.theme.add(t)
@@ -1034,16 +1046,17 @@ class Video_edit_testCase(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
-                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video="videos/remi/test.mp4", overview=u'videos/remi/1/overview.jpg',
+                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
                                  to_encode=False)
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.mp4"), encodingFormat="video/mp4")
         ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
         pod.channel.add(c)
         pod.theme.add(t)
         pod.save()
@@ -1135,16 +1148,17 @@ class Video_notesTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
-                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video="videos/remi/test.mp4", overview=u'videos/remi/1/overview.jpg',
+                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
                                  to_encode=False)
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.mp4"), encodingFormat="video/mp4")
         ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
 
         pod.channel.add(c)
         pod.theme.add(t)
@@ -1210,16 +1224,17 @@ class Video_completion_TestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
-                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video="videos/remi/test.mp4", overview=u'videos/remi/1/overview.jpg',
+                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
                                  to_encode=False)
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.mp4"), encodingFormat="video/mp4")
         ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
 
         pod.channel.add(c)
         pod.theme.add(t)
@@ -1538,17 +1553,18 @@ class Video_chapterTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
-                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video="videos/remi/test.mp4", overview="videos/remi/1/overview.jpg",
+                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
                                  to_encode=False)
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.mp4"), encodingFormat="video/mp4")
 
         ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
 
         pod.channel.add(c)
         pod.theme.add(t)
@@ -1708,28 +1724,29 @@ class Video_search_videos(TestCase):
         user.save()
 
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
-                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video="videos/remi/test.mp4", overview="videos/remi/1/overview.jpg",
+                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="bugs", is_draft=False,
                                  to_encode=False)
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.mp4"), encodingFormat="video/mp4")
 
         ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
         pod.save()
 
         pod2 = Pod.objects.create(type=other_type, title=u'NoIndex',
-                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video="videos/remi/test.mp4", overview="videos/remi/1/overview.jpg",
+                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="no index", is_draft=True,
                                  to_encode=False)
         EncodingPods.objects.create(video=pod2, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.mp4"), encodingFormat="video/mp4")
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod2, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
         pod2.save()
 
 
@@ -1806,17 +1823,18 @@ class Video_enrichTestView(TestCase):
         t = Theme.objects.create(
             title="Theme1", channel=c)
         other_type = Type.objects.get(id=1)
+        media_guard_hash = get_media_guard("remi")
         pod = Pod.objects.create(type=other_type, title=u'Bunny',
-                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video="videos/remi/test.mp4", overview="videos/remi/1/overview.jpg",
+                                 date_added=datetime.today().date(), owner=user, date_evt=datetime.today().date(), video=os.path.join("videos", "remi", media_guard_hash, "test.mp4"), overview=os.path.join('videos', 'remi', media_guard_hash, '1', 'overview.jpg'),
                                  allow_downloading=True, duration=33, encoding_in_progress=False, view_count=0, description="fl", is_draft=True,
                                  to_encode=False)
         EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-            id=1), encodingFile="videos/remi/1/video_1_240.mp4", encodingFormat="video/mp4")
+            id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.mp4"), encodingFormat="video/mp4")
 
         ENCODE_WEBM = getattr(settings, 'ENCODE_WEBM', True)
         if ENCODE_WEBM:
             EncodingPods.objects.create(video=pod, encodingType=EncodingType.objects.get(
-                id=1), encodingFile="videos/remi/1/video_1_240.webm", encodingFormat="video/webm")
+                id=1), encodingFile=os.path.join("videos", "remi", media_guard_hash, "1", "video_1_240.webm"), encodingFormat="video/webm")
 
         pod.channel.add(c)
         pod.theme.add(t)


### PR DESCRIPTION
Bonjour,

Cette pull request correspond à la carte trello : https://trello.com/c/AFTbDHnK

Elle ajoute deux paramètres optionnels :
MEDIA_GUARD = True
MEDIA_GUARD_SALT = "S3CR3T"

Cette fonctionnalité permet de protéger les médias physiquement sur le disque, en insérant un dossier dont le nom est un hash entre le dossier login et le dossier id. Si MEDIA_GUARD est à false, ce dossier intermédiaire n'est pas créé (fonctionnement retro-actif). 

Du coup, on ne peut pas récupérer les fichiers via l'url des média servis par nginx/apache sans connaitre le hash.

Le hash est un sha256 de "MEDIA_GUARD_SALT + login + pod.id". Pour les médias originaux (qui ne sont pas dans un dossier id), , le hash est "MEDIA_GUARD_SALT + login + 0".

L'intérêt de pouvoir recalculer le hash si on connait le MEDIA_GUARD_SALT est de pouvoir l'utiliser dans des scripts de migration de fichiers par exemple.

J'ai corrigé les tests unitaires pour qu'ils fonctionnent que la fonctionnalité soit activée ou non.

Cordialement,

Morgan
