### PR TITLE
Feature: missing class in object list headband

### DIFF
--- a/pod_project/pods/templates/channels/channels_list.html
+++ b/pod_project/pods/templates/channels/channels_list.html
@@ -29,7 +29,7 @@ voir http://www.gnu.org/licenses/
 			{% if channel.headband %}
                 <img alt="img" src="{% thumbnail channel.headband 285x160 crop upscale subject_location=channel.headband.subject_location %}" alt="{{channel.title}}" class="preview">
             {%else%}
-                <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{channel.title}}">
+                <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{channel.title}}" class="preview">
             {% endif %}
     		</span>
     		<h5>{{channel.title|safe|striptags|truncatechars:32}} ({{channel.video_count}})</h5>

--- a/pod_project/pods/templates/disciplines/disciplines_list.html
+++ b/pod_project/pods/templates/disciplines/disciplines_list.html
@@ -29,7 +29,7 @@ voir http://www.gnu.org/licenses/
     		{% if discipline.headband %}
                 <img src="{% thumbnail discipline.headband 285x160 crop upscale subject_location=discipline.headband.subject_location %}" alt="{{discipline.title}}" class="preview">
             {%else%}
-                <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{discipline.title}}">
+                <img alt="img" src="{% static DEFAULT_IMG %}" alt="{{discipline.title}}" class="preview">
             {% endif %}
     		</span>
     		<h5>{{discipline.title|safe|striptags|truncatechars:32}} ({{discipline.video_count}})</h5>


### PR DESCRIPTION
Adds « preview » missing CSS class to default headband IMG in « disciplines » and « channels » lists templates, so they display as « videos », « owners » and  « types » lists.

Before:
<img width="596" alt="before" src="https://cloud.githubusercontent.com/assets/10742818/19775674/7a2eb39e-9c71-11e6-8bfa-2b24b4021916.png">

After:
<img width="599" alt="after" src="https://cloud.githubusercontent.com/assets/10742818/19775683/809fff44-9c71-11e6-974d-a5775b3d6e25.png">

(Default headband IMGs are the right ones)
