### PR TITLE
use the FILE_UPLOAD_TEMP_DIR setting for the folder of the NamedTempo…

### DIFF
--- a/pod_project/core/utils.py
+++ b/pod_project/core/utils.py
@@ -360,7 +360,7 @@ def add_thumbnails(video_id, in_w, in_h, folder):
     video = Pod.objects.get(id=video_id)
     video.encoding_status = "ADD THUMBNAILS"
     video.save()
-    tempfile = NamedTemporaryFile()
+    tempfile = NamedTemporaryFile(dir=settings.FILE_UPLOAD_TEMP_DIR)
     media_guard_hash = get_media_guard(video.owner.username, video.id)
     scale = get_scale(in_w, in_h, DEFAULT_THUMBNAIL_OUT_SIZE_HEIGHT)
     thumbnails = int(video.duration / 3)


### PR DESCRIPTION
…raryFile in the thumbnails creation method.

Cela permet de rendre compatible la création des thumbnails avec la séparation de l'encodage.
En effet, on utilise un répertoire partagé dans FILE_UPLOAD_TEMP_DIR lors de la séparation de l'encodage.

Du coup, les machines d'encodage ont bien accès au thumbnails temporaires qui seront stockés dans ce répertoire partagé ( et non pas dans le /tmp de la VM web). Par défaut, si la variable n'est pas spécifié, ça prend '/tmp' par défaut.