### PR TITLE
Bugfix: calendar « today » link not localized

### DIFF
--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -32,11 +32,7 @@ http://www.gnu.org/licenses/
 
     <!-- media -->
     <script>window.__admin_media_prefix__ = "/static/admin/";</script>
-    {% if user.is_staff %}
-        <script src="/admin/jsi18n/"></script>
-    {% else %}
-        <script src="/dynamic-media/jsi18n/"></script>
-    {% endif %}
+    <script type="text/javascript" src="/my-admin/jsi18n/"></script>
     <script src="{{ STATIC_URL }}admin/js/core.js"></script>
     <script src="{{ STATIC_URL }}admin/js/jquery.js"></script>
     <script src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>

--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -31,7 +31,9 @@ http://www.gnu.org/licenses/
 {% block bootstrap3_extra_head %}
 
     <!-- media -->
-    <script>window.__admin_media_prefix__ = "/static/admin/";</script>
+    <script type="text/javascript">
+        window.__admin_media_prefix__ = "{% static 'admin/' %}";
+    </script>
     <script type="text/javascript" src="/my-admin/jsi18n/"></script>
     <script src="{{ STATIC_URL }}admin/js/core.js"></script>
     <script src="{{ STATIC_URL }}admin/js/jquery.js"></script>


### PR DESCRIPTION
This branch fixes a minor UI bug in the « video_edit » template, where the « today » link of the JS calendar is not localized for non-staff users.

Before:
<img width="179" alt="capture d ecran 2016-11-16 a 18 39 37" src="https://cloud.githubusercontent.com/assets/10742818/20358933/126e068e-ac2e-11e6-8619-d255cf7e18d4.png">

After:
<img width="174" alt="capture d ecran 2016-11-16 a 18 40 44" src="https://cloud.githubusercontent.com/assets/10742818/20358940/194f2e24-ac2e-11e6-9523-c1c5383d18ba.png">

It also removes hardcoded « static » path for « admin_media_prefix », needed for displaying the calendar icon if STATIC_URL isn't set to default value.
