### PR TITLE
Feature: use ownertools in videos list

### DIFF
--- a/pod_project/pods/templates/videos/ownertools.html
+++ b/pod_project/pods/templates/videos/ownertools.html
@@ -24,7 +24,7 @@ voir http://www.gnu.org/licenses/
     <a href="{% url 'video_edit' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Edit video information." %}">
         <span class="glyphicon glyphicon-pencil"></span><span class="sr-only">{% trans "Edit" %}</span>
     </a>
-    {%if user.is_staff%}
+    {% if user.is_staff %}
     <a href="{% url 'video_completion' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Add subtitle files, contributors, documents to download."%}">
         <span class="glyphicon glyphicon-paperclip"></span><span class="sr-only">{% trans "Completion" %}</span>
     </a>
@@ -32,22 +32,24 @@ voir http://www.gnu.org/licenses/
     <a href="{% url 'video_completion' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Add contributors."%}">
         <span class="glyphicon glyphicon-user"></span><span class="sr-only">{% trans "Completion" %}</span>
     </a>
-    {%endif%}
+    {% endif %}
     <a href="{% url 'video_chapter' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Divide the video into chapters." %}">
         <span class="glyphicon glyphicon-list"></span><span class="sr-only">{% trans "Chaptering" %}</span>
     </a>
-    {%if user.is_staff%}
+    {% if user.is_staff %}
     <a href="{% url 'video_enrich' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Add enrichments to the video." %}">
         <span class="glyphicon glyphicon-file"></span><span class="sr-only">{% trans "Enrich" %}</span>
     </a>
-    {%endif%}
+    {% endif %}
+    {% if withWatchIcon|default:'1' == '1' %}
     <a href="{% url 'video' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Watch the video." %}">
         <span class="glyphicon glyphicon-film"></span><span class="sr-only">{% trans "Watch" %}</span>
     </a>
+    {% endif %}
     {% if not video.encoding_in_progress %}
     <a href="{% url 'video_delete' slug=video.slug %}" class="btn btn-danger btn-xs" title="{% trans "Delete the video." %}">
         <span class="glyphicon glyphicon-remove"></span><span class="sr-only">{% trans "Delete" %}</span>
     </a>
-    {%endif%}
+    {% endif %}
 </span>
 {%endif%}

--- a/pod_project/pods/templates/videos/videos_list.html
+++ b/pod_project/pods/templates/videos/videos_list.html
@@ -88,27 +88,7 @@ voir http://www.gnu.org/licenses/
                 <h5>{{ video.title|truncatechars:36 }} {% is_new video %}</h5>
             </a>
             {% if user.is_authenticated and video.owner == request.user %}
-                <span class="user-tools hidden-xs"><!-- ONLY VISIBLE TO THE VIDEO OWNER ! -->
-                    <a href="{% url 'video_edit' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Edit video information.' %}">
-                        <span class="glyphicon glyphicon-pencil"></span><span class="sr-only">{% trans 'Edit' %}</span>
-                    </a>
-                    <a href="{% url 'video_completion' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add subtitle files, contributors, documents to download.' %}">
-                        <span class="glyphicon glyphicon-paperclip"></span><span class="sr-only">{% trans 'Completion' %}</span>
-                    </a>
-                    <a href="{% url 'video_chapter' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Divide the video into chapters.' %}">
-                        <span class="glyphicon glyphicon-list"></span><span class="sr-only">{% trans 'Chaptering' %}</span>
-                    </a>
-                    {% if user.is_staff %}
-                        <a href="{% url 'video_enrich' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add enrichments to the video.' %}">
-                            <span class="glyphicon glyphicon-file"></span><span class="sr-only">{% trans 'Enrich' %}</span>
-                        </a>
-                    {% endif %}
-                    {% if not video.encoding_in_progress %}
-                        <a href="{% url 'video_delete' slug=video.slug %}" class="btn btn-danger btn-xs" title="{% trans 'Delete' %}">
-                            <span class="glyphicon glyphicon-remove"></span><span class="sr-only">{% trans 'Delete' %}</span>
-                        </a>
-                    {% endif %}
-                </span>
+                {% include 'videos/ownertools.html' with withWatchIcon='0' %}
             {% endif %}
         </div>
     {% endfor %}


### PR DESCRIPTION
This branch replaces « video_list » owner tools markup by including the « ownertools » template, so non-staff users gets the « Add contributors » button instead of the staff-users one (paper-clip), and they are not told about subtitles and documents they cannot add.

Before:
<img width="294" alt="capture d ecran 2016-11-17 a 16 43 44" src="https://cloud.githubusercontent.com/assets/10742818/20399663/27ffb6cc-acf2-11e6-84ce-53566f13f00d.png">


After:
<img width="292" alt="capture d ecran 2016-11-17 a 16 44 15" src="https://cloud.githubusercontent.com/assets/10742818/20399667/2c041060-acf2-11e6-8bce-ae76a32c76f2.png">

From now on, every toolbar change will take place in the « ownertools » template.