### PR TITLE
Feature: clear up javascript calls and declarations in video templates

### DIFF
--- a/pod_project/core/templates/admin/base.html
+++ b/pod_project/core/templates/admin/base.html
@@ -6,7 +6,7 @@
 {% block extrastyle %}{% endblock %}
 <!--[if lte IE 7]><link rel="stylesheet" type="text/css" href="{% block stylesheet_ie %}{% static "admin/css/ie.css" %}{% endblock %}" /><![endif]-->
 {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}" />{% endif %}
-<script type="text/javascript">window.__admin_media_prefix__ = "{% filter escapejs %}{% static "admin/" %}{% endfilter %}";</script>
+<script type="text/javascript">window.__admin_media_prefix__ = "{% static 'admin/' %}";</script>
 {% block extrahead %}{% endblock %}
 {% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE" />{% endblock %}
 <link href="{% static 'css/admin.css' %}" rel="stylesheet">

--- a/pod_project/core/templates/fileBrowse.html
+++ b/pod_project/core/templates/fileBrowse.html
@@ -5,7 +5,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -25,7 +25,9 @@ voir http://www.gnu.org/licenses/
 		<link rel="stylesheet" href="{{ STATIC_URL }}admin/css/base.css" type="text/css" />
 		<link rel="stylesheet" href="{{ STATIC_URL }}admin/css/form.css" type="text/css" />
         <!-- media -->
-        <script type="text/javascript">window.__admin_media_prefix__ = "/static/admin/";</script>
+        <script type="text/javascript">
+            window.__admin_media_prefix__ = "{{ STATIC_URL }}admin/";
+        </script>
         <script type="text/javascript" src="/admin/jsi18n/"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/admin/RelatedObjectLookups.js"></script>
@@ -34,7 +36,7 @@ voir http://www.gnu.org/licenses/
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/actions.js"></script>
         <!-- form.media -->
         {{form.media}}
-        <!-- fin media -->	
+        <!-- fin media -->
         <script>
         var num=0;
         var name = "";
@@ -51,48 +53,48 @@ voir http://www.gnu.org/licenses/
 
             if (document.getElementById) {
                 document.getElementById("iframe").innerHTML = toThis;
-            } 
-            
+            }
+
             return false;
         }
-        
+
         function frameReady(){
             var el = document.getElementById('resultFrame');
             getIframeWindow(el).opener = window;
             //document.myform.style.visibility='hidden';
             document.myform.style.display = 'none';
         }
-        
+
         function getIframeWindow(iframe_object) {
           var doc;
-        
+
           if (iframe_object.contentWindow) {
             return iframe_object.contentWindow;
           }
-        
+
           if (iframe_object.window) {
             return iframe_object.window;
-          } 
-        
+          }
+
           if (!doc && iframe_object.contentDocument) {
             doc = iframe_object.contentDocument;
-          } 
-        
+          }
+
           if (!doc && iframe_object.document) {
             doc = iframe_object.document;
           }
-        
+
           if (doc && doc.defaultView) {
            return doc.defaultView;
           }
-        
+
           if (doc && doc.parentWindow) {
             return doc.parentWindow;
           }
-        
+
           return undefined;
         }
-        
+
         dismissRelatedImageLookupPopup = function(win, chosenId, chosenThumbnailUrl, chosenDescriptionTxt) {
     		//var name = windowname_to_id(win.name);
     		var img_name = name + '_thumbnail_img';
@@ -105,7 +107,7 @@ voir http://www.gnu.org/licenses/
     		document.getElementById(clear_name).style.display = 'inline';
     		document.myform.submit();
     	};
-        
+
         </script>
 	</head>
 	<body>
@@ -122,18 +124,18 @@ voir http://www.gnu.org/licenses/
         {{form.as_p}}
         <p><input type="submit" value="Valider" id="button_valider"/></p>
        </form>
-       
+
        <script type="text/javascript">
         (function($) {
             $(document).ready(function($) {
                 showRelatedObjectLookupPopup(document.getElementById("lookup_id_document"));
             });
         })(django.jQuery);
-        
+
         </script>
     </blockquote>
     <div id="iframe">
-        
+
     </div>
     {% endif%}
 	</body>

--- a/pod_project/core/templates/fileBrowse.html
+++ b/pod_project/core/templates/fileBrowse.html
@@ -30,9 +30,9 @@ voir http://www.gnu.org/licenses/
         </script>
         <script type="text/javascript" src="/admin/jsi18n/"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/admin/RelatedObjectLookups.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
+        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/admin/RelatedObjectLookups.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/actions.js"></script>
         <!-- form.media -->
         {{form.media}}

--- a/pod_project/core/templates/userProfile.html
+++ b/pod_project/core/templates/userProfile.html
@@ -25,7 +25,9 @@ voir http://www.gnu.org/licenses/
 
 {% block bootstrap3_extra_head %}
         <!-- media -->
-        <script type="text/javascript">window.__admin_media_prefix__ = "/static/admin/";</script>
+        <script type="text/javascript">
+            window.__admin_media_prefix__ = "{{ STATIC_URL }}admin/";
+        </script>
         <script type="text/javascript" src="/admin/jsi18n/"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/admin/RelatedObjectLookups.js"></script>
@@ -35,11 +37,11 @@ voir http://www.gnu.org/licenses/
         <!-- form.media -->
         {{form.media}}
         <!-- fin form.media -->
-<script>
-var messageBeforeUnload = "{% trans "Warning, you will leave this page. If you have made changes without clicking the Save button, your changes will be lost." %}";
-    var num=0;
-    var name = "";
-</script>
+        <script>
+            var messageBeforeUnload = "{% trans 'Warning, you will leave this page. If you have made changes without clicking the Save button, your changes will be lost.' %}",
+                num = 0,
+                name = "";
+        </script>
 {% endblock bootstrap3_extra_head %}
 
 

--- a/pod_project/core/templates/userProfile.html
+++ b/pod_project/core/templates/userProfile.html
@@ -24,19 +24,8 @@ voir http://www.gnu.org/licenses/
 {% block bootstrap3_title %}{{ block.super }}{% trans "My profile" %}{% endblock %}
 
 {% block bootstrap3_extra_head %}
-        <!-- media -->
-        <script type="text/javascript">
-            window.__admin_media_prefix__ = "{{ STATIC_URL }}admin/";
-        </script>
-        <script type="text/javascript" src="/admin/jsi18n/"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/admin/RelatedObjectLookups.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}admin/js/actions.js"></script>
-        <!-- form.media -->
-        {{form.media}}
-        <!-- fin form.media -->
         <script>
             var messageBeforeUnload = "{% trans 'Warning, you will leave this page. If you have made changes without clicking the Save button, your changes will be lost.' %}",
                 num = 0,
@@ -101,8 +90,11 @@ voir http://www.gnu.org/licenses/
     {% block box_info %}
 {% if not request.user.is_staff %}
 <div class="widget" style="text-align: justify">
-<h4><span class="glyphicon glyphicon-info-sign"></span> {% trans "Information"%}</h4>
-<p>{%trans "Your current permissions do not allow you to add a photo to your profile. Please contact us to add these rights."%} : <a href="mailto:{{HELP_MAIL}}">{{HELP_MAIL}}</a></p>
+    <h4><span class="glyphicon glyphicon-info-sign"></span> {% trans "Information"%}</h4>
+    <p>
+        {%trans "Your current permissions do not allow you to add a photo to your profile. Please contact us to add these rights."%}
+        <a href="mailto:{{HELP_MAIL}}">{{HELP_MAIL}}</a>
+    </p>
 </div>
 {%endif%}
     {% endblock box_info %}

--- a/pod_project/pod_project/urls-sample.py
+++ b/pod_project/pod_project/urls-sample.py
@@ -39,7 +39,6 @@ urlpatterns = [
     url(r'^browse/', 'core.views.file_browse', name='ckeditor_browse'),
 
     # Add-on for non-staff users
-    url(r'^dynamic-media/jsi18n/$', 'django.views.i18n.javascript_catalog'),
     url(r'^my-admin/jsi18n/',
         'django.views.i18n.javascript_catalog',
         {'packages': ('django.conf', 'django.contrib.admin')}),

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -37,7 +37,6 @@ voir http://www.gnu.org/licenses/
             background: white url({{ STATIC_URL }}admin/img/nav-bg.gif) bottom left repeat-x;
         }
     </style>
-    <!--script type="text/javascript">window.__admin_media_prefix__ = "/static/admin/";</script-->
     <script type="text/javascript" src="/admin/jsi18n/"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}admin/js/SelectBox.js"></script>

--- a/pod_project/pods/templates/search/search_video.html
+++ b/pod_project/pods/templates/search/search_video.html
@@ -34,7 +34,7 @@ voir http://www.gnu.org/licenses/
     </style>
 
     <script type="text/javascript">
-        window.__admin_media_prefix__ = '{% filter escapejs %}{% static 'admin/' %}{% endfilter %}';
+        window.__admin_media_prefix__ = "{% static 'admin/' %}";
     </script>
     <script type="text/javascript" src="/my-admin/jsi18n/"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>

--- a/pod_project/pods/templates/search/search_video.html
+++ b/pod_project/pods/templates/search/search_video.html
@@ -40,7 +40,6 @@ voir http://www.gnu.org/licenses/
     <script type="text/javascript" src="{{ STATIC_URL }}admin/js/core.js"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.js"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
-    <script type="text/javascript" src="{{ STATIC_URL }}admin/js/actions.js"></script>
     {{ form.media }}
     <script>
         $(document).ready(function() {

--- a/pod_project/pods/templates/videos/video_chapter.html
+++ b/pod_project/pods/templates/videos/video_chapter.html
@@ -91,18 +91,6 @@ voir http://www.gnu.org/licenses/
 <script src="{% static "video-js/video.js" %}" ></script>
 {% include "videos/extraheadplayer.html" with video=video %}
 
-<!-- media -->
-<script src="/admin/jsi18n/"></script>
-<script src="{% static 'admin/js/core.js' %}"></script>
-<script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>
-<script src="{% static 'admin/js/jquery.js' %}"></script>
-<script src="{% static 'admin/js/jquery.init.js' %}"></script>
-<script src="{% static 'admin/js/actions.js' %}"></script>
-
-<!-- form.media -->
-<script src="{% static 'filer/js/popup_handling.js' %}"></script>
-<script src="{% static 'ckeditor/ckeditor/ckeditor.js' %}"></script>
-
 <script>
 
 /*** table scroll ***/

--- a/pod_project/pods/templates/videos/video_chapter.html
+++ b/pod_project/pods/templates/videos/video_chapter.html
@@ -92,7 +92,6 @@ voir http://www.gnu.org/licenses/
 {% include "videos/extraheadplayer.html" with video=video %}
 
 <!-- media -->
-<script>window.__admin_media_prefix__ = '/static/admin/';</script>
 <script src="/admin/jsi18n/"></script>
 <script src="{% static 'admin/js/core.js' %}"></script>
 <script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>

--- a/pod_project/pods/templates/videos/video_completion.html
+++ b/pod_project/pods/templates/videos/video_completion.html
@@ -98,16 +98,12 @@ voir http://www.gnu.org/licenses/
 
 </style>
 
+{% if user.is_staff %}
 <!-- media -->
-<script src="/admin/jsi18n/"></script>
-<script src="{% static 'admin/js/core.js' %}"></script>
 <script src="{% static 'admin/js/jquery.js' %}"></script>
 <script src="{% static 'admin/js/jquery.init.js' %}"></script>
-<script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>
-<script src="{% static 'admin/js/actions.js' %}"></script>
-
 <!-- form.media -->
-<script src="{% static 'filer/js/popup_handling.js' %}"></script>
+{% endif %}
 
 <script>
 

--- a/pod_project/pods/templates/videos/video_completion.html
+++ b/pod_project/pods/templates/videos/video_completion.html
@@ -99,7 +99,6 @@ voir http://www.gnu.org/licenses/
 </style>
 
 <!-- media -->
-<script>window.__admin_media_prefix__ = '/static/admin/';</script>
 <script src="/admin/jsi18n/"></script>
 <script src="{% static 'admin/js/core.js' %}"></script>
 <script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>

--- a/pod_project/pods/templates/videos/video_completion.html
+++ b/pod_project/pods/templates/videos/video_completion.html
@@ -101,9 +101,9 @@ voir http://www.gnu.org/licenses/
 <!-- media -->
 <script src="/admin/jsi18n/"></script>
 <script src="{% static 'admin/js/core.js' %}"></script>
-<script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>
 <script src="{% static 'admin/js/jquery.js' %}"></script>
 <script src="{% static 'admin/js/jquery.init.js' %}"></script>
+<script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>
 <script src="{% static 'admin/js/actions.js' %}"></script>
 
 <!-- form.media -->

--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -31,7 +31,9 @@ http://www.gnu.org/licenses/
 {% block bootstrap3_extra_head %}
 
     <!-- media -->
-    <script>window.__admin_media_prefix__ = "/static/admin/";</script>
+    <script type="text/javascript">
+        window.__admin_media_prefix__ = "{% static 'admin/' %}";
+    </script>
     {% if user.is_staff %}
         <script src="/admin/jsi18n/"></script>
     {% else %}

--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -42,9 +42,6 @@ http://www.gnu.org/licenses/
     <script src="{{ STATIC_URL }}admin/js/core.js"></script>
     <script src="{{ STATIC_URL }}admin/js/jquery.js"></script>
     <script src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
-    <!--
-    <script src="{{ STATIC_URL }}admin/js/admin/RelatedObjectLookups.js"></script>
-    <script src="{{ STATIC_URL }}admin/js/actions.js"></script>
     <!-- form.media -->
     <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}admin/css/widgets.css"/>
     {{form.media}}

--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -34,11 +34,7 @@ http://www.gnu.org/licenses/
     <script type="text/javascript">
         window.__admin_media_prefix__ = "{% static 'admin/' %}";
     </script>
-    {% if user.is_staff %}
-        <script src="/admin/jsi18n/"></script>
-    {% else %}
-        <script src="/dynamic-media/jsi18n/"></script>
-    {% endif %}
+    <script type="text/javascript" src="/my-admin/jsi18n/"></script>
     <script src="{{ STATIC_URL }}admin/js/core.js"></script>
     <script src="{{ STATIC_URL }}admin/js/jquery.js"></script>
     <script src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>

--- a/pod_project/pods/templates/videos/video_enrich.html
+++ b/pod_project/pods/templates/videos/video_enrich.html
@@ -96,19 +96,14 @@ voir http://www.gnu.org/licenses/
 
 </style>
 
-<script src="{% static "video-js/video.js" %}" ></script>
+<script src="{% static 'video-js/video.js' %}" ></script>
 {% include "videos/extraheadplayer.html" with video=video %}
 
 <!-- media -->
-<script src="/admin/jsi18n/"></script>
-<script src="{% static 'admin/js/core.js' %}"></script>
-<script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>
 <script src="{% static 'admin/js/jquery.js' %}"></script>
 <script src="{% static 'admin/js/jquery.init.js' %}"></script>
-<script src="{% static 'admin/js/actions.js' %}"></script>
 
 <!-- form.media -->
-<script src="{% static 'filer/js/popup_handling.js' %}"></script>
 <script src="{% static 'ckeditor/ckeditor/ckeditor.js' %}"></script>
 
 <script>

--- a/pod_project/pods/templates/videos/video_enrich.html
+++ b/pod_project/pods/templates/videos/video_enrich.html
@@ -100,7 +100,6 @@ voir http://www.gnu.org/licenses/
 {% include "videos/extraheadplayer.html" with video=video %}
 
 <!-- media -->
-<script>window.__admin_media_prefix__ = '/static/admin/';</script>
 <script src="/admin/jsi18n/"></script>
 <script src="{% static 'admin/js/core.js' %}"></script>
 <script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>


### PR DESCRIPTION
This branch modifies video templates by removing unused JS files calls and _admin_media_prefix_ declarations, using the « my-admin » route for JS catalog (instead of the _admin_ or _dynamic-media_ ones) and removing hardcoded « static » paths.

As a result, there are no more errors like this
![typeerror](https://cloud.githubusercontent.com/assets/10742818/20487235/e32641ec-b002-11e6-84a1-b58d623a866e.png)
in the JS console, and no more access denied
![jsi18n_403](https://cloud.githubusercontent.com/assets/10742818/20487279/09a352ba-b003-11e6-975a-4d007c7ff991.png)
on I18N js catalog when the user is non-staff.