### PR TITLE
Hotfix: tags are case and accent insensitive

### DIFF
--- a/pod_project/pod_project/settings-sample.py
+++ b/pod_project/pod_project/settings-sample.py
@@ -203,6 +203,12 @@ FILER_ENABLE_PERMISSIONS = True
 
 
 ##
+# Taggit config
+#
+TAGGIT_CASE_INSENSITIVE = True
+
+
+##
 # Easy-thumbnails config (Django-filer)
 #
 THUMBNAIL_PROCESSORS = (


### PR DESCRIPTION
Prevents Taggit from generating
> IntegrityError: (1062, "Duplicate entry 'gniiii' for key 'taggit_tag_name_4ed9aad194b72af1_uniq’ »)

which results in a 500 when associating existing tags spelled with uppercases or accented characters to videos.

https://github.com/alex/django-taggit/issues/9
https://github.com/alex/django-taggit/issues/308