### PR TITLE
Feature: videojs upgrade mods

### DIFF
--- a/pod_project/core/theme/DEFAULT/assets/css/pod.css
+++ b/pod_project/core/theme/DEFAULT/assets/css/pod.css
@@ -603,8 +603,9 @@ ul li.vjs-menu-title.vjs-disp-menu-title:hover {
   max-width: 99%;
   max-height: 99%;
 }
-.video-js .vjs-text-track {
+.video-js .vjs-text-track-display > div > div > div {
   font-size: 1.4em !important;
+  background-color: rgba(0, 0, 0, 0.7) !important;
 }
 .vjs-default-skin .vjs-big-play-button {
   width: 95% !important;

--- a/pod_project/core/theme/DEFAULT/less/includes/_pod.less
+++ b/pod_project/core/theme/DEFAULT/less/includes/_pod.less
@@ -718,8 +718,9 @@ ul li.vjs-menu-title.vjs-disp-menu-title:hover {
         }
     }
 
-    .vjs-text-track {
+    .vjs-text-track-display > div > div > div {
         font-size: @vjsSubtitleSize !important;
+        background-color: rgba(0, 0, 0, 0.7) !important;
     }
 }
 

--- a/pod_project/core/theme/DEFAULT/less/includes/_settings.less
+++ b/pod_project/core/theme/DEFAULT/less/includes/_settings.less
@@ -22,7 +22,7 @@
 @navbarEndColor:            #ee7d19;            // Same value = no gradient
 
 @footerLinkColor:           #3f9ec2;            // Footer links color
-@footerLinkTopMargin:       5px;                // Footer links top margin (do not apply to the first one)
+@footerLinkTopMargin:       5px;                // Footer links top margin (does not apply to the first one)
 @footerLinkPadding:         6px 12px;           // Footer links padding
 @footerStartColor:          #333;               // Footer vertical gradient colors (top -> bottom)
 @footerEndColor:            #333;               // Same value = no gradient

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -651,6 +651,8 @@ class TrackPods(models.Model):
             msg.append(_('please enter a correct lang.'))
         if not self.src:
             msg.append(_('please specify a track file.'))
+        if not str(self.src).lower().endswith('.vtt'):
+            msg.append(_('only “.vtt” format is allowed.'))
         if (len(msg) > 0):
             return msg
         else:

--- a/pod_project/pods/templates/videos/completion/contributor/form_contributor.html
+++ b/pod_project/pods/templates/videos/completion/contributor/form_contributor.html
@@ -5,7 +5,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -24,12 +24,12 @@ voir http://www.gnu.org/licenses/
     {% csrf_token %}
     <div id="formcontent" class="form-container">
         {% if form_contributor.errors or form_contributor.non_field_errors %}
-            {% trans "Your form contains errors" %}: <br/>
+            {% trans "Your form contains errors:" %}<br/>
             {% for error in form_contributor.non_field_errors %}
                 - {{error}} <br/>
             {%endfor%}
         {%endif%}
-       
+
         {% for field_hidden in form_contributor.hidden_fields %}
         {{ field_hidden }}
         {% endfor %}

--- a/pod_project/pods/templates/videos/completion/download/form_download.html
+++ b/pod_project/pods/templates/videos/completion/download/form_download.html
@@ -5,7 +5,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -23,14 +23,13 @@ voir http://www.gnu.org/licenses/
 <form  id="form_download" action="{% url 'video_completion_download' slug=video.slug  %}" method="post" >
     {% csrf_token %}
     <div id="formcontent" class="form-container">
-        &nbsp;
         {% if form_download.errors or form_download.non_field_errors %}
-            {% trans "Your form contains errors" %}: <br/>
+            {% trans "Your form contains errors:" %}<br/>
             {% for error in form_download.non_field_errors %}
                 - {{error}} <br/>
             {%endfor%}
         {%endif%}
-       
+
         {% for field_hidden in form_download.hidden_fields %}
         {{ field_hidden }}
         {% endfor %}

--- a/pod_project/pods/templates/videos/completion/subtitle/form_subtitle.html
+++ b/pod_project/pods/templates/videos/completion/subtitle/form_subtitle.html
@@ -5,7 +5,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -23,14 +23,13 @@ voir http://www.gnu.org/licenses/
 <form  id="form_subtitle" action="{% url 'video_completion_subtitle' slug=video.slug  %}" method="post" >
     {% csrf_token %}
     <div id="formcontent" class="form-container">
-        &nbsp;
         {% if form_subtitle.errors or form_subtitle.non_field_errors %}
-            {% trans "Your form contains errors" %}: <br/>
+            {% trans "Your form contains errors:" %}<br/>
             {% for error in form_subtitle.non_field_errors %}
                 - {{error}} <br/>
             {%endfor%}
         {%endif%}
-       
+
         {% for field_hidden in form_subtitle.hidden_fields %}
         {{ field_hidden }}
         {% endfor %}

--- a/pod_project/pods/templates/videos/video_completion.html
+++ b/pod_project/pods/templates/videos/video_completion.html
@@ -393,6 +393,11 @@ function verify_fields(form){
             .before("<span class='form-help-inline'>&nbsp;&nbsp;{% trans 'Please specify a track file.' %} </span>")
             .parents('div.form-group').addClass('has-error');
         }
+        if(document.getElementById("id_src_description_txt").innerText.split('.').pop() != "vtt" ){
+            $("input#id_src")
+            .before("<span class='form-help-inline'>&nbsp;&nbsp;{% trans 'Only “.vtt” format is allowed.' %} </span>")
+            .parents('div.form-group').addClass('has-error');
+        }
         var kind = document.getElementById("id_kind").value;
         var lang = document.getElementById("id_lang").value;
         var id = parseInt(document.getElementById("id_subtitle").value);

--- a/pod_project/pods/templates/videos/video_completion.html
+++ b/pod_project/pods/templates/videos/video_completion.html
@@ -535,6 +535,7 @@ function verify_fields(form){
             {% if request.user.is_staff %}
                 <p>{% trans 'Several web sites allows you to subtitle or caption videos (for example: Amara).' %}</p>
                 <p>{% trans 'You can add several subtitle or caption files to a single video (for example, in order to subtitle or caption this video in several languages).' %}</p>
+                <p>{% trans 'Those files must be in “.vtt” format.' %}</p>
                 <p>{% trans 'For this purpose, you will need the URL of your video. This URL is a direct access to this video. Please do not communicate it outside of this site in order to avoid any misuse.' %}</p>
                 <input maxlength="250" value="//{{ request.get_host }}{{ video.get_MP4_240_URL }}" type="text" style="padding: 2px; border: 1px solid #bbb; width: 260px;" />
             {% else %}

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -1705,6 +1705,10 @@ msgstr "Veuillez renseigner une langue."
 msgid "please specify a track file."
 msgstr "Veuillez spécifier un fichier de sous-titre ou de légende."
 
+#: pods/models.py:654
+msgid "only “.vtt” format is allowed."
+msgstr "seul le format « .vtt » est autorisé."
+
 #: pods/models.py:667
 msgid ""
 "there is already a subtitle with the same kind and language in the list."

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -1695,15 +1695,15 @@ msgstr "Pistes"
 
 #: pods/models.py:648
 msgid "please enter a correct kind."
-msgstr "Veuillez renseigner le type de piste."
+msgstr "veuillez renseigner le type de piste."
 
 #: pods/models.py:650
 msgid "please enter a correct lang."
-msgstr "Veuillez renseigner une langue."
+msgstr "veuillez renseigner une langue."
 
 #: pods/models.py:652
 msgid "please specify a track file."
-msgstr "Veuillez spécifier un fichier de sous-titre ou de légende."
+msgstr "veuillez spécifier un fichier de sous-titre ou de légende."
 
 #: pods/models.py:654
 msgid "only “.vtt” format is allowed."
@@ -1712,7 +1712,7 @@ msgstr "seul le format « .vtt » est autorisé."
 #: pods/models.py:667
 msgid ""
 "there is already a subtitle with the same kind and language in the list."
-msgstr "Un sous-titrage de même nature et de même langue existe déjà."
+msgstr "un sous-titrage de même nature et de même langue existe déjà."
 
 #: pods/models.py:684
 msgid "Document Pod"
@@ -2677,6 +2677,10 @@ msgstr "Veuillez sélectionner une langue."
 #: pods/templates/videos/video_completion.html:393
 msgid "Please specify a track file."
 msgstr "Veuillez indiquer un fichier de sous-titre ou de légende."
+
+#: pods/templates/videos/video_completion.html:398
+msgid "Only “.vtt” format is allowed."
+msgstr "Seul le format « .vtt » est autorisé."
 
 #: pods/templates/videos/video_completion.html:402
 msgid ""

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-05 15:10+0200\n"
-"PO-Revision-Date: 2016-12-06 16:53+0100\n"
+"POT-Creation-Date: 2017-01-03 17:05+0100\n"
+"PO-Revision-Date: 2017-01-03 17:10+0100\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: ESUP POD <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: core/admin.py:77 core/models.py:272
+#: core/admin.py:77 core/models.py:288
 msgid "Email"
 msgstr "Courriel"
 
@@ -25,23 +25,23 @@ msgstr "Courriel"
 msgid "Please indicate the result of the following operation hereunder"
 msgstr "Veuillez compléter le champ ci-dessous avec le résultat de l'opération"
 
-#: core/models.py:72
+#: core/models.py:73
 msgid "order"
 msgstr "ordre"
 
-#: core/models.py:76
+#: core/models.py:77
 msgid "page bottom menu"
 msgstr "élément du menu de pied de page"
 
-#: core/models.py:77
+#: core/models.py:78
 msgid "pages bottom menu"
 msgstr "éléments du menu de pied de page"
 
-#: core/models.py:90
+#: core/models.py:91
 msgid "Avatar"
 msgstr "Photo de profil"
 
-#: core/models.py:91
+#: core/models.py:92
 msgid ""
 "This field allows you to add a photo ID. The picture will be displayed with "
 "your videos."
@@ -49,12 +49,12 @@ msgstr ""
 "Ce champ vous permet d'ajouter une photo d'identité. L'image sera affichée "
 "avec vos vidéos."
 
-#: core/models.py:92 core/models.py:174 pods/models.py:66
-#: pods/templates/videos/video_edit.html:512
+#: core/models.py:93 core/models.py:188 pods/models.py:66
+#: pods/templates/videos/video_edit.html:507
 msgid "Description"
 msgstr "Description"
 
-#: core/models.py:93
+#: core/models.py:94
 msgid ""
 "This field allows you to write a few words about yourself. The text will be "
 "displayed with your videos."
@@ -62,49 +62,55 @@ msgstr ""
 "Ce champ vous permet d'écrire quelques mots sur vous-même. Le texte sera "
 "affiché avec vos vidéos."
 
-#: core/models.py:94 pods/models.py:565 pods/models.py:760
+#: core/models.py:95 pods/models.py:566 pods/models.py:763
 #: pods/templates/videos/completion/contributor/list_contributor.html:35
 msgid "Web link"
 msgstr "Lien web"
 
-#: core/models.py:95
+#: core/models.py:96
 msgid "This field allows you to add an url."
 msgstr "Ce champ vous permet d'ajouter une adresse web."
 
-#: core/models.py:99 pods/models.py:1086
+#: core/models.py:100 pods/models.py:1089
 msgid "Comment"
 msgstr "Commentaire"
 
-#: core/models.py:105 core/templates/header.html:69
+#: core/models.py:106 core/templates/header.html:69
 msgid "Profile"
 msgstr "Profil"
 
-#: core/models.py:106
+#: core/models.py:107
 msgid "Profiles"
 msgstr "Profils"
 
-#: core/models.py:153 pods/models.py:330 pods/models.py:506 pods/models.py:680
-#: pods/models.py:1083
+#: core/models.py:166 pods/models.py:330 pods/models.py:507 pods/models.py:683
+#: pods/models.py:1086
 msgid "Video"
 msgstr "Vidéo"
 
-#: core/models.py:155
+#: core/models.py:168
 msgid "allow downloading"
 msgstr "Autoriser le téléchargement"
 
-#: core/models.py:156 pods/models.py:60 pods/models.py:111 pods/models.py:152
-#: pods/templates/videos/chapter/list_chapter.html:31
-#: pods/templates/videos/enrich/list_enrich.html:32
-#: pods/templates/videos/video_edit.html:457
+#: core/models.py:169
+#, fuzzy
+#| msgid "video"
+msgid "video 360"
+msgstr "video"
+
+#: core/models.py:170 pods/models.py:60 pods/models.py:111 pods/models.py:152
+#: pods/templates/videos/chapter/list_chapter.html:34
+#: pods/templates/videos/enrich/list_enrich.html:34
+#: pods/templates/videos/video_edit.html:452
 msgid "Title"
 msgstr "Titre"
 
-#: core/models.py:157 pods/models.py:62 pods/models.py:113 pods/models.py:154
+#: core/models.py:171 pods/models.py:62 pods/models.py:113 pods/models.py:154
 msgid "Slug"
 msgstr "Titre web"
 
-#: core/models.py:159 pods/models.py:64 pods/models.py:115 pods/models.py:156
-#: pods/models.py:192 pods/models.py:734 pods/models.py:889
+#: core/models.py:173 pods/models.py:64 pods/models.py:115 pods/models.py:156
+#: pods/models.py:192 pods/models.py:737 pods/models.py:892
 msgid ""
 "Used to access this instance, the \"slug\" is a short label containing only "
 "letters, numbers, underscore or dash top."
@@ -113,109 +119,109 @@ msgstr ""
 "étiquette formée uniquement de lettres (non accentuées), de chiffres, de "
 "l'underscore (barre de soulignement) et du tiret."
 
-#: core/models.py:161 core/templates/admin/filer/folder/directory_table.html:14
+#: core/models.py:175 core/templates/admin/filer/folder/directory_table.html:14
 #: core/templates/admin/filer/folder/directory_table.html:33
-#: core/templates/admin/filer/folder/directory_table.html:81 pods/admin.py:107
-#: pods/templates/search/search_video.html:163
+#: core/templates/admin/filer/folder/directory_table.html:81 pods/admin.py:120
+#: pods/templates/search/search_video.html:168
 msgid "Owner"
 msgstr "Propriétaire"
 
-#: core/models.py:163
+#: core/models.py:177
 msgid "Date added"
 msgstr "Date de mise en ligne"
 
-#: core/models.py:165
+#: core/models.py:179
 msgid "Date of event"
 msgstr "Date de l'évènement"
 
-#: core/models.py:168 pods/templates/search/search_video.html:238
-#: pods/templates/videos/video_edit.html:485
+#: core/models.py:182 pods/templates/search/search_video.html:243
+#: pods/templates/videos/video_edit.html:480
 msgid "University course"
 msgstr "Cursus universitaire"
 
-#: core/models.py:171 pods/templates/search/search_video.html:225
-#: pods/templates/videos/video_edit.html:499
+#: core/models.py:185 pods/templates/search/search_video.html:230
+#: pods/templates/videos/video_edit.html:494
 msgid "Main language"
 msgstr "Langue principale"
 
-#: core/models.py:177
+#: core/models.py:191
 msgid "View count"
 msgstr "Nombre de vues"
 
-#: core/models.py:180
+#: core/models.py:194
 msgid "Encoding in progress"
 msgstr "Encodage en cours"
 
-#: core/models.py:182
+#: core/models.py:196
 msgid "Encoding status"
 msgstr "Statut d'encodage"
 
-#: core/models.py:185 core/models.py:220
+#: core/models.py:199 core/models.py:236
 msgid "Thumbnail"
 msgstr "Vignette"
 
-#: core/models.py:190
+#: core/models.py:204
 msgid "Overview"
 msgstr "Vue d'ensemble"
 
-#: core/models.py:193 core/models.py:226 pods/templates/videos/video.html:313
+#: core/models.py:207 core/models.py:242 pods/templates/videos/video.html:318
 msgid "Duration"
 msgstr "Durée"
 
-#: core/models.py:199 core/models.py:200 pods/models.py:544 pods/models.py:620
-#: pods/models.py:729 pods/models.py:884
+#: core/models.py:215 core/models.py:216 pods/models.py:545 pods/models.py:621
+#: pods/models.py:732 pods/models.py:887
 msgid "video"
 msgstr "video"
 
-#: core/models.py:236 pods/models.py:1030 pods/models.py:1048
+#: core/models.py:252 pods/models.py:1033 pods/models.py:1051
 msgid "name"
 msgstr "nom"
 
-#: core/models.py:238
+#: core/models.py:254
 msgid "bitrate_audio"
 msgstr "bitrate audio"
 
-#: core/models.py:240
+#: core/models.py:256
 msgid "bitrate_video"
 msgstr "bitrate video"
 
-#: core/models.py:250
+#: core/models.py:266
 msgid "output_height"
 msgstr "hauteur de sortie"
 
-#: core/models.py:256
+#: core/models.py:272
 msgid "mediatype"
 msgstr "type du media"
 
-#: core/models.py:259
+#: core/models.py:275
 msgid "encoding type"
 msgstr "réglage d'encodage"
 
-#: core/models.py:260
+#: core/models.py:276
 msgid "encoding types"
 msgstr "réglages d'encodage"
 
-#: core/models.py:271 core/templates/admin/filer/folder/directory_table.html:12
+#: core/models.py:287 core/templates/admin/filer/folder/directory_table.html:12
 msgid "Name"
 msgstr "Nom"
 
-#: core/models.py:273
+#: core/models.py:289
 msgid "Subject"
 msgstr "Sujet"
 
-#: core/models.py:274
+#: core/models.py:290
 msgid "Message"
 msgstr "Message"
 
-#: core/models.py:277
+#: core/models.py:293
 msgid "Contact"
 msgstr "Contact"
 
-#: core/models.py:278
+#: core/models.py:294
 msgid "Contacts"
 msgstr "Contacts"
 
-#: core/populatedCASbackend.py:116
+#: core/populatedCASbackend.py:133
 msgid "Unable to authenticate"
 msgstr "Impossible de vous authentifier"
 
@@ -229,9 +235,9 @@ msgid "You are not authorized to view this resource"
 msgstr "Vous n'êtes pas autorisé à accéder à cette ressource"
 
 #: core/templates/403.html:51 core/templates/404.html:51
-#: core/templates/admin/base.html:47 core/templates/base.html:96
+#: core/templates/admin/base.html:47 core/templates/base.html:98
 #: core/templates/contactus/contactus.html:43 core/templates/navbar.html:41
-#: core/templates/registration/login.html:99 core/templates/userProfile.html:81
+#: core/templates/registration/login.html:99 core/templates/userProfile.html:72
 msgid "Home"
 msgstr "Accueil"
 
@@ -342,12 +348,10 @@ msgid "Delete '%(item_label)s'"
 msgstr "Supprimer '%(item_label)s'"
 
 #: core/templates/admin/filer/folder/directory_table.html:86
-#: pods/templates/videos/chapter/list_chapter.html:55
-#: pods/templates/videos/enrich/list_enrich.html:60
-#: pods/templates/videos/ownertools.html:49
+#: pods/templates/videos/chapter/list_chapter.html:59
+#: pods/templates/videos/enrich/list_enrich.html:63
+#: pods/templates/videos/ownertools.html:51
 #: pods/templates/videos/video_delete.html:73
-#: pods/templates/videos/videos_list.html:107
-#: pods/templates/videos/videos_list.html:108
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -442,79 +446,79 @@ msgstr "Effacer"
 msgid "Lookup"
 msgstr "Rechercher un fichier"
 
-#: core/templates/base.html:54
+#: core/templates/base.html:56
 msgid "Warning, your session will expire soon."
 msgstr "Attention, votre session va expirer bientôt."
 
-#: core/templates/base.html:55
+#: core/templates/base.html:57
 msgid "Your session has expired."
 msgstr "Votre session a expiré."
 
-#: core/templates/base.html:143
+#: core/templates/base.html:145
 msgid "Share"
 msgstr "Partager"
 
-#: core/templates/base.html:157 core/templates/base.html.py:164
+#: core/templates/base.html:159 core/templates/base.html.py:166
 #: pods/models.py:210 pods/models.py:305
 #: pods/templates/disciplines/disciplines.html:24
 #: pods/templates/disciplines/disciplines.html:31
 #: pods/templates/disciplines/disciplines.html:39
 #: pods/templates/disciplines/disciplines.html:41
 #: pods/templates/disciplines/disciplines.html:74
-#: pods/templates/videos/video_edit.html:555
+#: pods/templates/videos/video_edit.html:550
 #: pods/templates/videos/videos.html:106
 msgid "Disciplines"
 msgstr "Disciplines"
 
-#: core/templates/base.html:158
+#: core/templates/base.html:160
 msgid "See all"
 msgstr "Afficher tout"
 
-#: core/templates/base.html:177 pods/models.py:302
-#: pods/templates/search/search_video.html:187 pods/templates/tags/tags.html:25
+#: core/templates/base.html:179 pods/models.py:302
+#: pods/templates/search/search_video.html:192 pods/templates/tags/tags.html:25
 #: pods/templates/tags/tags.html.py:86 pods/templates/tags/tags.html:96
-#: pods/templates/tags/tags.html.py:104 pods/templates/videos/video.html:287
+#: pods/templates/tags/tags.html.py:104 pods/templates/videos/video.html:292
 #: pods/templates/videos/videos.html:130
 msgid "Tags"
 msgstr "Mots clés"
 
-#: core/templates/base.html:178
+#: core/templates/base.html:180
 msgid "See the cloud"
 msgstr "Voir le nuage"
 
-#: core/templates/base.html:197 pods/models.py:985
+#: core/templates/base.html:199 pods/models.py:988
 msgid "Notes"
 msgstr "Notes"
 
-#: core/templates/base.html:205 pods/templates/channels/channel_edit.html:163
-#: pods/templates/channels/channel_edit.html:164
+#: core/templates/base.html:207 pods/templates/channels/channel_edit.html:162
+#: pods/templates/channels/channel_edit.html:163
 #: pods/templates/pagination.html:41
-#: pods/templates/videos/chapter/form_chapter.html:43
-#: pods/templates/videos/enrich/form_enrich.html:43
-#: pods/templates/videos/video.html:475 pods/templates/videos/video.html:476
-#: pods/templates/videos/video_edit.html:358
+#: pods/templates/videos/chapter/form_chapter.html:42
+#: pods/templates/videos/enrich/form_enrich.html:42
+#: pods/templates/videos/video.html:480 pods/templates/videos/video.html:481
+#: pods/templates/videos/video_edit.html:353
 msgid "Save"
 msgstr "Enregistrer"
 
-#: core/templates/base.html:215 core/templates/registration/login.html:116
-#: core/templates/userProfile.html:102
+#: core/templates/base.html:217 core/templates/registration/login.html:116
+#: core/templates/userProfile.html:93
 #: pods/templates/channels/my_channels.html:76
 #: pods/templates/videos/my_videos.html:64
-#: pods/templates/videos/video_chapter.html:380
-#: pods/templates/videos/video_completion.html:519
-#: pods/templates/videos/video_enrich.html:482
+#: pods/templates/videos/video_chapter.html:378
+#: pods/templates/videos/video_completion.html:533
+#: pods/templates/videos/video_enrich.html:491
 msgid "Information"
 msgstr "Information"
 
-#: core/templates/base.html:242
+#: core/templates/base.html:244
 msgid "My files"
 msgstr "Mes fichiers"
 
-#: core/templates/base.html:243
+#: core/templates/base.html:245
 msgid "You will find here all your folders and files."
 msgstr "Vous trouverez ici tous vos dossiers et fichiers."
 
-#: core/templates/base.html:248
+#: core/templates/base.html:250
 msgid ""
 "\"upload\" allows you to import one or more files from your computer.<br/> "
 "The \"Clipboard\" is a temporary space that welcomes new files and files to "
@@ -532,34 +536,34 @@ msgstr ""
 "gauche d'un fichier pour sélectionner un fichier. N'hésitez pas à regarder "
 "la vidéo d'aide pour l'utilisation du gestionnaire de fichier."
 
-#: core/templates/base.html:251 core/templates/base.html.py:275
+#: core/templates/base.html:253 core/templates/base.html.py:277
 msgid "Close"
 msgstr "Fermer"
 
-#: core/templates/base.html:264
+#: core/templates/base.html:266
 msgid "Report this video"
 msgstr "Signaler cette vidéo"
 
-#: core/templates/base.html:270
+#: core/templates/base.html:272
 msgid "Please, specify the problem:"
 msgstr "Veuillez expliquer le problème :"
 
-#: core/templates/base.html:276 core/templates/contactus/contactus.html:35
-#: core/templates/header.html:50 core/templates/userProfile.html:73
+#: core/templates/base.html:278 core/templates/contactus/contactus.html:35
+#: core/templates/header.html:50 core/templates/userProfile.html:64
 #: pods/templates/mediacourses/mediacourses_add.html:65
-#: pods/templates/videos/video.html:169 pods/templates/videos/video.html:170
-#: pods/templates/videos/video.html:207 pods/templates/videos/video.html:225
+#: pods/templates/videos/video.html:174 pods/templates/videos/video.html:175
+#: pods/templates/videos/video.html:212 pods/templates/videos/video.html:230
 msgid "Send"
 msgstr "Envoyer"
 
 #: core/templates/contactus/contactus.html:26
-#: core/templates/userProfile.html:64 core/views.py:165
-#: pods/templates/channels/channel_edit.html:84
+#: core/templates/userProfile.html:55 core/views.py:166
+#: pods/templates/channels/channel_edit.html:83
 #: pods/templates/mediacourses/mediacourses_add.html:52
-#: pods/templates/videos/video_chapter.html:258
-#: pods/templates/videos/video_edit.html:325
-#: pods/templates/videos/video_enrich.html:255 pods/views.py:196
-#: pods/views.py:461 pods/views.py:708 pods/views.py:712 pods/views.py:1653
+#: pods/templates/videos/video_chapter.html:249
+#: pods/templates/videos/video_edit.html:320
+#: pods/templates/videos/video_enrich.html:255 pods/views.py:201
+#: pods/views.py:478 pods/views.py:727 pods/views.py:731 pods/views.py:1683
 msgid "One or more errors have been found in the form."
 msgstr "Une ou plusieurs erreurs ont été trouvées dans le formulaire."
 
@@ -569,8 +573,8 @@ msgid "Erase"
 msgstr "Effacer"
 
 #: core/templates/contactus/contactus.html:41
-#: core/templates/registration/login.html:97 core/templates/userProfile.html:79
-#: core/templates/userProfile.html.py:85
+#: core/templates/registration/login.html:97 core/templates/userProfile.html:70
+#: core/templates/userProfile.html.py:76
 msgid "Back"
 msgstr "Retour"
 
@@ -578,7 +582,7 @@ msgstr "Retour"
 msgid "Here are the latest videos"
 msgstr "Voici les dernières vidéos"
 
-#: core/templates/header.html:41 pods/models.py:630
+#: core/templates/header.html:41 pods/models.py:631
 #: pods/templates/videos/completion/subtitle/list_subtitle.html:34
 msgid "Language"
 msgstr "Langue"
@@ -620,12 +624,12 @@ msgstr "Connexion"
 #: pods/templates/channels/channels.html:39
 #: pods/templates/channels/channels.html:41
 #: pods/templates/videos/video.html:141
-#: pods/templates/videos/video_edit.html:573
+#: pods/templates/videos/video_edit.html:568
 msgid "Channels"
 msgstr "Chaînes"
 
 #: core/templates/navbar.html:76 core/templates/navbar.html.py:92
-#: pods/models.py:76 pods/templates/channels/channel_edit.html:178
+#: pods/models.py:76 pods/templates/channels/channel_edit.html:177
 #: pods/templates/owners/owners.html:24 pods/templates/owners/owners.html:39
 #: pods/templates/owners/owners.html:41 pods/templates/videos/videos.html:52
 msgid "Users"
@@ -641,20 +645,21 @@ msgstr "Types"
 #: core/templates/navbar.html:115 pods/models.py:331
 #: pods/templates/videos/video.html:144 pods/templates/videos/videos.html:26
 #: pods/templates/videos/videos.html:30 pods/templates/videos/videos.html:32
+#: pods/templates/videos/videos_iframe.html:25
 msgid "Videos"
 msgstr "Vidéos"
 
 #: core/templates/navbar.html:119 pods/templates/videos/video_edit.html:26
-#: pods/templates/videos/video_edit.html:281
-#: pods/templates/videos/video_edit.html:316
+#: pods/templates/videos/video_edit.html:276
+#: pods/templates/videos/video_edit.html:311
 msgid "Add a new video"
 msgstr "Ajouter une nouvelle vidéo"
 
 #: core/templates/navbar.html:123 core/templates/navbar.html.py:127
-#: pods/forms.py:322 pods/templates/search/search_video.html:25
-#: pods/templates/search/search_video.html:55
-#: pods/templates/search/search_video.html:65
-#: pods/templates/search/search_video.html:153
+#: pods/forms.py:333 pods/templates/search/search_video.html:25
+#: pods/templates/search/search_video.html:54
+#: pods/templates/search/search_video.html:64
+#: pods/templates/search/search_video.html:158
 #: pods/templates/videos/videos.html:54
 msgid "Search"
 msgstr "Rechercher"
@@ -683,23 +688,23 @@ msgstr "N'hésitez pas à nous contacter pour toute assistance :"
 
 #: core/templates/registration/login.html:118
 #: core/templates/registration/login.html:119
-#: core/theme/LILLE1/templates/footer.html:27
-#: core/theme/LILLE1/templates/footer.html:28 core/views.py:223
-#: pods/templates/videos/video.html:175
+#: core/theme/DEFAULT/templates/footer.html:27
+#: core/theme/DEFAULT/templates/footer.html:28 core/views.py:226
+#: pods/templates/videos/video.html:180
 msgid "Contact us"
 msgstr "Contactez nous"
 
 #: core/templates/userProfile.html:24
-#: pods/templates/channels/channel_edit.html:71
+#: pods/templates/channels/channel_edit.html:70
 msgid "My profile"
 msgstr "Mon profil"
 
-#: core/templates/userProfile.html:39
-#: pods/templates/channels/channel_edit.html:56
+#: core/templates/userProfile.html:30
+#: pods/templates/channels/channel_edit.html:55
 #: pods/templates/mediacourses/mediacourses_add.html:31
-#: pods/templates/videos/video_chapter.html:131
+#: pods/templates/videos/video_chapter.html:122
 #: pods/templates/videos/video_completion.html:175
-#: pods/templates/videos/video_edit.html:152
+#: pods/templates/videos/video_edit.html:147
 #: pods/templates/videos/video_enrich.html:137
 msgid ""
 "Warning, you will leave this page. If you have made changes without clicking "
@@ -708,18 +713,18 @@ msgstr ""
 "Attention, vous quittez cette page. Si vous avez apporté des modifications "
 "sans cliquer sur le bouton Enregistrer, vos modifications seront perdues."
 
-#: core/templates/userProfile.html:47 core/templates/userProfile.html.py:57
+#: core/templates/userProfile.html:38 core/templates/userProfile.html.py:48
 msgid "My Profile"
 msgstr "Mon profil"
 
-#: core/templates/userProfile.html:76
-#: pods/templates/videos/chapter/form_chapter.html:44
-#: pods/templates/videos/enrich/form_enrich.html:44
+#: core/templates/userProfile.html:67
+#: pods/templates/videos/chapter/form_chapter.html:43
+#: pods/templates/videos/enrich/form_enrich.html:43
 #: pods/templates/videos/video_delete.html:71
 msgid "Cancel"
 msgstr "Annuler"
 
-#: core/templates/userProfile.html:103
+#: core/templates/userProfile.html:95
 msgid ""
 "Your current permissions do not allow you to add a photo to your profile. "
 "Please contact us to add these rights."
@@ -727,28 +732,28 @@ msgstr ""
 "Vos permissions actuelles ne vous permettent pas d’ajouter une photo à votre "
 "profil. Veuillez nous contacter pour vous ajouter ces droits."
 
-#: core/theme/LILLE1/templates/footer.html:30
-#: core/theme/LILLE1/templates/footer.html:31
+#: core/theme/DEFAULT/templates/footer.html:30
+#: core/theme/DEFAULT/templates/footer.html:31
 msgid "FAQ"
 msgstr "Foire aux questions"
 
-#: core/views.py:92
+#: core/views.py:93
 msgid "Login"
 msgstr "Identifiant"
 
-#: core/views.py:94 pods/admin.py:130 pods/forms.py:308
-#: pods/templates/videos/video_edit.html:636
+#: core/views.py:95 pods/admin.py:146 pods/forms.py:318
+#: pods/templates/videos/video_edit.html:633
 msgid "Password"
 msgstr "Mot de passe"
 
-#: core/views.py:114
+#: core/views.py:115
 msgid ""
 "Your account is disabled, please contact the administrator of the platform."
 msgstr ""
 "Votre compte est désactivé, veuillez contacter l'administrateur de la plate-"
 "forme."
 
-#: core/views.py:119
+#: core/views.py:120
 msgid ""
 "Unable to connect. Please check your credentials and try again, or contact "
 "the platform administrator."
@@ -756,11 +761,11 @@ msgstr ""
 "Connexion impossible. veuillez vérifier vos identifiants et ré-essayer, ou "
 "contacter l'administrateur de la plate-forme."
 
-#: core/views.py:162
+#: core/views.py:163
 msgid "Your profile is saved."
 msgstr "Votre profil est enregistré."
 
-#: core/views.py:180
+#: core/views.py:181
 #, python-format
 msgid ""
 "\n"
@@ -785,7 +790,7 @@ msgstr ""
 "<p>Provenance : <a href=\"%(url)s\">%(url)s</a></p>\n"
 "\n"
 
-#: core/views.py:196
+#: core/views.py:197
 #, python-format
 msgid ""
 "\n"
@@ -814,17 +819,17 @@ msgstr "Votre message intitulé"
 msgid "Your message has been sent."
 msgstr "Votre message a bien été envoyé"
 
-#: django_cas_gateway/views.py:82
+#: django_cas_gateway/views.py:84
 #, python-format
 msgid "You are logged in as %s."
 msgstr "Vous êtes connecté en tant que %s."
 
-#: django_cas_gateway/views.py:94
+#: django_cas_gateway/views.py:98
 #, python-format
 msgid "Login succeeded. Welcome, %s."
 msgstr " Bienvenue, %s. "
 
-#: django_cas_gateway/views.py:100
+#: django_cas_gateway/views.py:104
 msgid "<h1>Forbidden</h1><p>Login failed.</p>"
 msgstr "<h1>Interdit</h1><p>Connexion erronée.</p>"
 
@@ -945,7 +950,6 @@ msgid "Dutch"
 msgstr ""
 
 #: pod_project/ISOLanguageCodes.py:38 pod_project/ISOLanguageCodes.py:158
-#: pod_project/settings.py:119
 msgid "English"
 msgstr ""
 
@@ -974,7 +978,6 @@ msgid "Finnish"
 msgstr ""
 
 #: pod_project/ISOLanguageCodes.py:45 pod_project/ISOLanguageCodes.py:162
-#: pod_project/settings.py:118
 msgid "French"
 msgstr ""
 
@@ -1434,19 +1437,19 @@ msgstr "Autre"
 msgid "Owners"
 msgstr "Propriétaires"
 
-#: pods/admin.py:139
+#: pods/admin.py:155
 msgid "Encode selected"
 msgstr "(Ré)encoder la sélection"
 
-#: pods/forms.py:147
+#: pods/forms.py:150
 msgid "Filetype not allowed! Filetypes allowed: "
 msgstr "Type de fichier non admis ! Les types de fichiers acceptés sont : "
 
-#: pods/forms.py:153 pods/templates/videos/video_edit.html:472
+#: pods/forms.py:156 pods/templates/videos/video_edit.html:467
 msgid "Date of the event"
 msgstr "Date de l'évènement"
 
-#: pods/forms.py:155 pods/templates/videos/video_edit.html:443
+#: pods/forms.py:158 pods/templates/videos/video_edit.html:438
 msgid "File"
 msgstr "Fichier"
 
@@ -1478,7 +1481,7 @@ msgstr ""
 "plate-forme."
 
 #: pods/models.py:86 pods/models.py:120
-#: pods/templates/search/search_video.html:212
+#: pods/templates/search/search_video.html:217
 msgid "Channel"
 msgstr "Chaîne"
 
@@ -1492,29 +1495,29 @@ msgstr "Thème"
 
 #: pods/models.py:135 pods/models.py:309
 #: pods/templates/channels/channel.html:120
-#: pods/templates/channels/channel_edit.html:97
-#: pods/templates/videos/video_edit.html:591
+#: pods/templates/channels/channel_edit.html:96
+#: pods/templates/videos/video_edit.html:586
 msgid "Themes"
 msgstr "Thèmes"
 
-#: pods/models.py:173 pods/models.py:303 pods/models.py:754
-#: pods/templates/search/search_video.html:175
-#: pods/templates/videos/enrich/list_enrich.html:33
-#: pods/templates/videos/video.html:319
-#: pods/templates/videos/video_edit.html:539
+#: pods/models.py:173 pods/models.py:303 pods/models.py:757
+#: pods/templates/search/search_video.html:180
+#: pods/templates/videos/enrich/list_enrich.html:35
+#: pods/templates/videos/video.html:324
+#: pods/templates/videos/video_edit.html:534
 msgid "Type"
 msgstr "Type"
 
-#: pods/models.py:188 pods/models.py:730 pods/models.py:885 pods/models.py:999
+#: pods/models.py:188 pods/models.py:733 pods/models.py:888 pods/models.py:1002
 msgid "title"
 msgstr "titre"
 
-#: pods/models.py:190 pods/models.py:732 pods/models.py:887
+#: pods/models.py:190 pods/models.py:735 pods/models.py:890
 msgid "slug"
 msgstr "titre court"
 
-#: pods/models.py:209 pods/templates/search/search_video.html:199
-#: pods/templates/videos/video.html:326
+#: pods/models.py:209 pods/templates/search/search_video.html:204
+#: pods/templates/videos/video.html:331
 msgid "Discipline"
 msgstr "Discipline"
 
@@ -1526,7 +1529,7 @@ msgstr ""
 "Séparez les mots-clés avec des espaces, placez les mots-clés constitués de "
 "plusieurs mots entre guillemets."
 
-#: pods/models.py:314 pods/templates/videos/video_edit.html:608
+#: pods/models.py:314 pods/templates/videos/video_edit.html:605
 msgid "Draft"
 msgstr "Brouillon"
 
@@ -1537,8 +1540,8 @@ msgstr ""
 "Si cette case est cochée, la vidéo sera visible et accessible uniquement par "
 "vous."
 
-#: pods/models.py:319 pods/models.py:1060
-#: pods/templates/videos/video_edit.html:621
+#: pods/models.py:319 pods/models.py:1063
+#: pods/templates/videos/video_edit.html:618
 msgid "Restricted access"
 msgstr "Accès restreint"
 
@@ -1560,379 +1563,375 @@ msgstr ""
 "Le visionnage de la vidéo ne pourra se faire qu'après avoir fourni ce mot de "
 "passe."
 
-#: pods/models.py:508
+#: pods/models.py:509
 msgid "encodingType"
 msgstr "type d'encodage"
 
-#: pods/models.py:510
+#: pods/models.py:511
 msgid "encodingFile"
 msgstr "Fichier résultant"
 
-#: pods/models.py:518
+#: pods/models.py:519
 msgid "Format"
 msgstr "format"
 
-#: pods/models.py:526
+#: pods/models.py:527
 msgid "encoding"
 msgstr "encodage"
 
-#: pods/models.py:527
+#: pods/models.py:528
 msgid "encodings"
 msgstr "encodages"
 
-#: pods/models.py:545
+#: pods/models.py:546
 msgid "lastname / firstname"
 msgstr "Nom / Prénom"
 
-#: pods/models.py:547
+#: pods/models.py:548
 msgid "mail"
 msgstr "courriel"
 
-#: pods/models.py:549
+#: pods/models.py:550
 msgid "actor"
 msgstr "acteur"
 
-#: pods/models.py:550
+#: pods/models.py:551
 msgid "author"
 msgstr "auteur"
 
-#: pods/models.py:551
+#: pods/models.py:552
 msgid "designer"
 msgstr "concepteur"
 
-#: pods/models.py:552
+#: pods/models.py:553
 msgid "consultant"
 msgstr "consultant"
 
-#: pods/models.py:553
+#: pods/models.py:554
 msgid "contributor"
 msgstr "contributeur"
 
-#: pods/models.py:554
+#: pods/models.py:555
 msgid "editor"
 msgstr "éditeur"
 
-#: pods/models.py:555
+#: pods/models.py:556
 msgid "speaker"
 msgstr "intervenant"
 
-#: pods/models.py:556
+#: pods/models.py:557
 msgid "soundman"
 msgstr "preneur de son"
 
-#: pods/models.py:557
+#: pods/models.py:558
 msgid "director"
 msgstr "réalisateur"
 
-#: pods/models.py:558
+#: pods/models.py:559
 msgid "writer"
 msgstr "scénariste"
 
-#: pods/models.py:559
+#: pods/models.py:560
 msgid "technician"
 msgstr "technicien"
 
-#: pods/models.py:560
+#: pods/models.py:561
 msgid "voice-over"
 msgstr "voix-off"
 
-#: pods/models.py:563
+#: pods/models.py:564
 msgid "role"
 msgstr "rôle"
 
-#: pods/models.py:563
-msgid "authors"
-msgstr "auteurs"
-
-#: pods/models.py:568
+#: pods/models.py:569
 msgid "Contributor Pod"
 msgstr "Contributeur"
 
-#: pods/models.py:569
+#: pods/models.py:570
 msgid "Contributors Pod"
 msgstr "Contributeurs"
 
-#: pods/models.py:581
+#: pods/models.py:582
 msgid "please enter a name from 2 to 200 caracteres."
 msgstr "Veuillez renseigner un titre contenant entre 2 et 100 caractères. "
 
-#: pods/models.py:584
+#: pods/models.py:585
 msgid "you cannot enter a weblink with more than 200 caracteres."
 msgstr "les liens internet doivent être inférieur à 200 caractères. "
 
-#: pods/models.py:586
+#: pods/models.py:587
 msgid "please enter a role."
 msgstr "Veuillez renseigner un rôle."
 
-#: pods/models.py:601
+#: pods/models.py:602
 msgid "there is already a contributor with the same name and role in the list."
 msgstr "Un contributeur avec le même nom et le même role existe déjà."
 
-#: pods/models.py:623
+#: pods/models.py:624
 msgid "subtitles"
 msgstr "sous-titres"
 
-#: pods/models.py:624
+#: pods/models.py:625
 msgid "captions"
 msgstr "légendes"
 
-#: pods/models.py:627
+#: pods/models.py:628
 #: pods/templates/videos/completion/subtitle/list_subtitle.html:33
 msgid "Kind"
 msgstr "Genre"
 
-#: pods/models.py:632
+#: pods/models.py:633
 msgid "subtitle file"
 msgstr "fichier de sous-titres"
 
-#: pods/models.py:635
+#: pods/models.py:636
 msgid "Track Pod"
 msgstr "Piste"
 
-#: pods/models.py:636
+#: pods/models.py:637
 msgid "Tracks Pod"
 msgstr "Pistes"
 
-#: pods/models.py:648
+#: pods/models.py:649
 msgid "please enter a correct kind."
 msgstr "veuillez renseigner le type de piste."
 
-#: pods/models.py:650
+#: pods/models.py:651
 msgid "please enter a correct lang."
 msgstr "veuillez renseigner une langue."
 
-#: pods/models.py:652
+#: pods/models.py:653
 msgid "please specify a track file."
 msgstr "veuillez spécifier un fichier de sous-titre ou de légende."
 
-#: pods/models.py:654
+#: pods/models.py:655
 msgid "only “.vtt” format is allowed."
 msgstr "seul le format « .vtt » est autorisé."
 
-#: pods/models.py:667
+#: pods/models.py:670
 msgid ""
 "there is already a subtitle with the same kind and language in the list."
 msgstr "un sous-titrage de même nature et de même langue existe déjà."
 
-#: pods/models.py:684
+#: pods/models.py:687
 msgid "Document Pod"
 msgstr "Document"
 
-#: pods/models.py:685
+#: pods/models.py:688
 msgid "Documents Pod"
 msgstr "Documents"
 
-#: pods/models.py:702
+#: pods/models.py:705
 msgid "please enter a document "
 msgstr "veuillez sélectionner un document "
 
-#: pods/models.py:718
+#: pods/models.py:721
 msgid "this document is already contained in the list."
 msgstr "Ce document a déjà été envoyé."
 
-#: pods/models.py:737
+#: pods/models.py:740
 msgid "Stop video"
 msgstr "Arrêter la lecture"
 
-#: pods/models.py:738
+#: pods/models.py:741
 msgid "The video will pause when displaying this enrichment."
 msgstr "La vidéo se met en pause lors de l'affichage de cet enrichissement."
 
-#: pods/models.py:740 pods/templates/videos/enrich/list_enrich.html:34
+#: pods/models.py:743 pods/templates/videos/enrich/list_enrich.html:36
 msgid "Start"
 msgstr "Début"
 
-#: pods/models.py:741
+#: pods/models.py:744
 msgid "Start of enrichment display in seconds"
 msgstr "Début d'affichage de l'enrichissement en secondes"
 
-#: pods/models.py:743 pods/templates/videos/enrich/list_enrich.html:35
+#: pods/models.py:746 pods/templates/videos/enrich/list_enrich.html:37
 msgid "End"
 msgstr "Fin"
 
-#: pods/models.py:744
+#: pods/models.py:747
 msgid "End of enrichment display in seconds"
 msgstr "Fin d'affichage de l'enrichissement en secondes"
 
-#: pods/models.py:747
+#: pods/models.py:750
 msgid "image"
 msgstr "image"
 
-#: pods/models.py:748 pods/models.py:758
+#: pods/models.py:751 pods/models.py:761
 msgid "richtext"
 msgstr "texte enrichi et mis en forme"
 
-#: pods/models.py:749
+#: pods/models.py:752
 msgid "weblink"
 msgstr "lien web"
 
-#: pods/models.py:750
+#: pods/models.py:753
 msgid "document"
 msgstr "document"
 
-#: pods/models.py:751
+#: pods/models.py:754
 msgid "embed"
 msgstr "intégrer"
 
-#: pods/models.py:764
+#: pods/models.py:767
 msgid "Integrate an document (PDF, text, html)"
 msgstr "Afficher un document (PDF, texte ou html)"
 
-#: pods/models.py:766
+#: pods/models.py:769
 msgid "Embed"
 msgstr "Intégrer"
 
-#: pods/models.py:768
+#: pods/models.py:771
 msgid "Integrate an external source"
 msgstr "Afficher une source externe (video youtube par exemple)"
 
-#: pods/models.py:771
+#: pods/models.py:774
 msgid "Enrichment"
 msgstr "Enrichissement"
 
-#: pods/models.py:772
+#: pods/models.py:775
 msgid "Enrichments"
 msgstr "Enrichissements"
 
-#: pods/models.py:793 pods/models.py:916
-#: pods/templates/videos/video_chapter.html:281
+#: pods/models.py:796 pods/models.py:919
+#: pods/templates/videos/video_chapter.html:272
 #: pods/templates/videos/video_enrich.html:327
 msgid "Please enter a title from 2 to 100 characters."
 msgstr "Veuillez renseigner un titre contenant entre 2 et 100 caractères."
 
-#: pods/models.py:796 pods/models.py:919
+#: pods/models.py:799 pods/models.py:922
 #, python-format
 msgid "Please enter a correct start field between 0 and %(duration)s."
 msgstr ""
 "Veuillez renseigner une valeur de début d'enrichissement comprise entre 0 et "
 "%(duration)s."
 
-#: pods/models.py:800
+#: pods/models.py:803
 #, python-format
 msgid "Please enter a correct end field between 1 and %(duration)s."
 msgstr ""
 "Veuillez renseigner une valeur de fin d'enrichissement comprise entre 1 et "
 "%(duration)s."
 
-#: pods/models.py:804 pods/templates/videos/video_enrich.html:345
+#: pods/models.py:807 pods/templates/videos/video_enrich.html:345
 msgid "Please enter a correct image."
 msgstr "Veuillez renseigner une image."
 
-#: pods/models.py:808 pods/templates/videos/video_enrich.html:352
+#: pods/models.py:811 pods/templates/videos/video_enrich.html:352
 msgid "Please enter a correct richtext."
 msgstr "Veuillez renseigner un texte."
 
-#: pods/models.py:812 pods/templates/videos/video_enrich.html:359
+#: pods/models.py:815 pods/templates/videos/video_enrich.html:359
 msgid "Please enter a correct weblink."
 msgstr "Veuillez renseigner un lien internet."
 
-#: pods/models.py:816 pods/templates/videos/video_completion.html:410
+#: pods/models.py:819 pods/templates/videos/video_completion.html:415
 #: pods/templates/videos/video_enrich.html:372
 msgid "Please select a document."
 msgstr "Veuillez sélectionner un document."
 
-#: pods/models.py:820 pods/templates/videos/video_enrich.html:379
+#: pods/models.py:823 pods/templates/videos/video_enrich.html:379
 msgid "Please enter a correct embed."
 msgstr "Veuillez renseigner un code embed."
 
-#: pods/models.py:822 pods/templates/videos/video_enrich.html:391
+#: pods/models.py:825 pods/templates/videos/video_enrich.html:391
 msgid "Please enter a type in index field."
 msgstr "Veuillez choisir un type d'enrichissement."
 
-#: pods/models.py:834
+#: pods/models.py:837
 msgid "The value of the start field is greater than the value of end field."
 msgstr "La valeur du commencement ne peut être supérieure à celle de la fin."
 
-#: pods/models.py:837
+#: pods/models.py:840
 msgid "The value of end field is greater than the video duration."
 msgstr ""
 "La valeur de fin d'enrichissement est supérieure à la durée de la vidéo."
 
-#: pods/models.py:839
+#: pods/models.py:842
 msgid "End field and start field can't be equal."
 msgstr "Le commencement et la fin ne peuvent être équivalents."
 
-#: pods/models.py:857 pods/templates/videos/video_enrich.html:421
+#: pods/models.py:860 pods/templates/videos/video_enrich.html:421
 msgid "There is an overlap with the enrichment "
 msgstr "Il y a un chevauchement avec l'enrichissement "
 
-#: pods/models.py:892 pods/templates/videos/chapter/list_chapter.html:35
+#: pods/models.py:895 pods/templates/videos/chapter/list_chapter.html:35
 msgid "Start time"
 msgstr "Début"
 
-#: pods/models.py:893
+#: pods/models.py:896
 msgid "Start time of the chapter, in seconds."
 msgstr "Début du chapitre, en secondes."
 
-#: pods/models.py:896
+#: pods/models.py:899
 msgid "Chapter"
 msgstr "Chapitre"
 
-#: pods/models.py:897
+#: pods/models.py:900
 msgid "Chapters"
 msgstr "Chapitres"
 
-#: pods/models.py:937
+#: pods/models.py:940
 msgid "There is an overlap with the chapter "
 msgstr "Il y a un chevauchement avec le chapitre "
 
-#: pods/models.py:967
+#: pods/models.py:970
 msgid "Favorite"
 msgstr "Favoris"
 
-#: pods/models.py:968
+#: pods/models.py:971
 msgid "Favorites"
 msgstr "Mes favoris"
 
-#: pods/models.py:981 pods/models.py:984
+#: pods/models.py:984 pods/models.py:987
 msgid "Note"
 msgstr "Note"
 
-#: pods/models.py:1007
+#: pods/models.py:1010
 msgid "Mediacourse"
 msgstr "Mediacours"
 
-#: pods/models.py:1008
+#: pods/models.py:1011
 msgid "Mediacourses"
 msgstr "Mediacours"
 
-#: pods/models.py:1042 pods/models.py:1049
+#: pods/models.py:1045 pods/models.py:1052
 msgid "Building"
 msgstr "Bâtiment"
 
-#: pods/models.py:1043
+#: pods/models.py:1046
 msgid "Buildings"
 msgstr "Bâtiments"
 
-#: pods/models.py:1051
+#: pods/models.py:1054
 msgid "description"
 msgstr "description"
 
-#: pods/models.py:1062
+#: pods/models.py:1065
 msgid "Live is accessible only to authenticated users."
 msgstr "La vidéo est accessible uniquement aux utilisateurs authentifiés."
 
-#: pods/models.py:1075
+#: pods/models.py:1078
 msgid "Recorder"
 msgstr "Enregistreur"
 
-#: pods/models.py:1076
+#: pods/models.py:1079
 msgid "Recorders"
 msgstr "Enregistreurs"
 
-#: pods/models.py:1084
+#: pods/models.py:1087
 msgid "User"
 msgstr "Utilisateur"
 
-#: pods/models.py:1087
+#: pods/models.py:1090
 msgid "Answer"
 msgstr "Réponse"
 
-#: pods/models.py:1103
+#: pods/models.py:1106
 msgid "Report"
 msgstr "Signaler"
 
-#: pods/models.py:1104
+#: pods/models.py:1107
 msgid "Reports"
 msgstr "Signalements"
 
@@ -2014,28 +2013,28 @@ msgid "no video found"
 msgstr "Aucune vidéo trouvée"
 
 #: pods/templates/channels/channel_edit.html:27
-#: pods/templates/channels/channel_edit.html:69
-#: pods/templates/channels/channel_edit.html:71
+#: pods/templates/channels/channel_edit.html:68
+#: pods/templates/channels/channel_edit.html:70
 msgid "Edition of the channel"
 msgstr "Édition de la chaîne"
 
-#: pods/templates/channels/channel_edit.html:121
-#: pods/templates/channels/channel_edit.html:148
+#: pods/templates/channels/channel_edit.html:120
+#: pods/templates/channels/channel_edit.html:147
 msgid "Delete this theme"
 msgstr "Supprimer ce thème"
 
-#: pods/templates/channels/channel_edit.html:155
+#: pods/templates/channels/channel_edit.html:154
 msgid "Add a new theme"
 msgstr "Ajouter un nouveau thème"
 
+#: pods/templates/channels/channel_edit.html:165
 #: pods/templates/channels/channel_edit.html:166
-#: pods/templates/channels/channel_edit.html:167
-#: pods/templates/videos/video_edit.html:361
+#: pods/templates/videos/video_edit.html:356
 msgid "Save and return to previous page"
 msgstr "Enregistrer et revenir à la page précédente"
 
+#: pods/templates/channels/channel_edit.html:168
 #: pods/templates/channels/channel_edit.html:169
-#: pods/templates/channels/channel_edit.html:170
 msgid "Save and see channel"
 msgstr "Enregistrer et voir la chaîne"
 
@@ -2097,11 +2096,11 @@ msgstr "Ajouter un nouvel enregistrement"
 #: pods/templates/videos/my_videos.html:24
 #: pods/templates/videos/my_videos.html:32
 #: pods/templates/videos/my_videos.html:43
-#: pods/templates/videos/video_chapter.html:340
-#: pods/templates/videos/video_completion.html:439
+#: pods/templates/videos/video_chapter.html:332
+#: pods/templates/videos/video_completion.html:445
 #: pods/templates/videos/video_delete.html:35
-#: pods/templates/videos/video_edit.html:278
-#: pods/templates/videos/video_enrich.html:444
+#: pods/templates/videos/video_edit.html:273
+#: pods/templates/videos/video_enrich.html:445
 msgid "My videos"
 msgstr "Mes vidéos"
 
@@ -2120,51 +2119,61 @@ msgstr[1] "%(counter)s utilisateurs ayant posté"
 msgid "Show all"
 msgstr "Tout afficher"
 
-#: pods/templates/search/search_video.html:77
+#: pods/templates/search/search_video.html:76
 #, python-format
 msgid "%(counter)s video found"
 msgid_plural "%(counter)s videos found"
 msgstr[0] "%(counter)s vidéo trouvée"
 msgstr[1] "%(counter)s vidéos trouvées"
 
-#: pods/templates/search/search_video.html:85
+#: pods/templates/search/search_video.html:84
 msgid "Search results"
 msgstr "Résultat(s) de la recherche"
 
-#: pods/templates/search/search_video.html:106
-msgid "This content is protected by authentication and/or password."
-msgstr "Ce contenu est protégé par authentification et/ou mot de passe."
+#: pods/templates/search/search_video.html:105
+#: pods/templates/videos/videos_list.html:48
+msgid "This content is only accessible to authenticated users."
+msgstr "Ce contenu est uniquement accessible aux utilisateurs authentifiés."
 
-#: pods/templates/search/search_video.html:109
+#: pods/templates/search/search_video.html:108
+#: pods/templates/videos/videos_list.html:51
+msgid "This content is password protected."
+msgstr "Ce contenu est protégé par mot de passe."
+
+#: pods/templates/search/search_video.html:111
 #: pods/templates/videos/videos_list.html:54
 msgid "This content has enrichments (files, web links, etc.)."
 msgstr "Ce contenu est enrichi (documents joints, liens web, etc.)."
 
-#: pods/templates/search/search_video.html:112
+#: pods/templates/search/search_video.html:114
+#: pods/templates/videos/videos_list.html:57
+msgid "This content is chaptered."
+msgstr "Ce contenu est chapitré."
+
+#: pods/templates/search/search_video.html:117
 #: pods/templates/videos/videos_list.html:62
 msgid "Video content."
 msgstr "Contenu de type vidéo."
 
-#: pods/templates/search/search_video.html:114
+#: pods/templates/search/search_video.html:119
 #: pods/templates/videos/videos_list.html:65
 msgid "Audio content."
 msgstr "Contenu de type audio."
 
-#: pods/templates/search/search_video.html:134
+#: pods/templates/search/search_video.html:139
 msgid "No videos match your request."
 msgstr "Aucune vidéo ne correspond à votre recherche."
 
-#: pods/templates/search/search_video.html:144
+#: pods/templates/search/search_video.html:149
 msgid "Advanced Search"
 msgstr "Recherche avancée"
 
-#: pods/templates/search/search_video.html:147
+#: pods/templates/search/search_video.html:152
 #: pods/templates/videos/ownertools.html:25
-#: pods/templates/videos/videos_list.html:93
 msgid "Edit"
 msgstr "Modifier"
 
-#: pods/templates/search/search_video.html:159
+#: pods/templates/search/search_video.html:164
 msgid "faceting"
 msgstr "Affiner"
 
@@ -2180,38 +2189,38 @@ msgstr[1] "%(counter)s types"
 msgid "One or more errors have been found in the form:"
 msgstr "Une ou plusieurs erreurs ont été trouvées dans le formulaire :"
 
-#: pods/templates/videos/chapter/list_chapter.html:26
+#: pods/templates/videos/chapter/list_chapter.html:27
 msgid "List of chapters"
 msgstr "Liste des chapitres"
 
-#: pods/templates/videos/chapter/list_chapter.html:47
+#: pods/templates/videos/chapter/list_chapter.html:51
 msgid "Edit the chapter"
 msgstr "Modifier le chapitre"
 
-#: pods/templates/videos/chapter/list_chapter.html:47
-#: pods/templates/videos/enrich/list_enrich.html:52
+#: pods/templates/videos/chapter/list_chapter.html:51
+#: pods/templates/videos/enrich/list_enrich.html:55
 msgid "Modify"
 msgstr "Modifier"
 
-#: pods/templates/videos/chapter/list_chapter.html:55
+#: pods/templates/videos/chapter/list_chapter.html:59
 msgid "Delete the chapter"
 msgstr "Supprimer le chapitre"
 
 #: pods/templates/videos/completion/contributor/form_contributor.html:27
-#: pods/templates/videos/completion/download/form_download.html:28
-#: pods/templates/videos/completion/subtitle/form_subtitle.html:28
+#: pods/templates/videos/completion/download/form_download.html:27
+#: pods/templates/videos/completion/subtitle/form_subtitle.html:27
 msgid "Your form contains errors:"
 msgstr "Le formulaire contient des erreurs :"
 
 #: pods/templates/videos/completion/contributor/form_contributor.html:43
-#: pods/templates/videos/completion/download/form_download.html:44
-#: pods/templates/videos/completion/subtitle/form_subtitle.html:44
+#: pods/templates/videos/completion/download/form_download.html:43
+#: pods/templates/videos/completion/subtitle/form_subtitle.html:43
 msgid "save"
 msgstr "sauvegarder"
 
 #: pods/templates/videos/completion/contributor/form_contributor.html:44
-#: pods/templates/videos/completion/download/form_download.html:45
-#: pods/templates/videos/completion/subtitle/form_subtitle.html:45
+#: pods/templates/videos/completion/download/form_download.html:44
+#: pods/templates/videos/completion/subtitle/form_subtitle.html:44
 msgid "cancel"
 msgstr "annuler"
 
@@ -2283,19 +2292,19 @@ msgstr "Editer les fichiers de sous-titre ou de légende"
 msgid "Delete the subtitle or the caption"
 msgstr "Supprimer le fichier de sous-titre ou de légende"
 
-#: pods/templates/videos/enrich/list_enrich.html:26
+#: pods/templates/videos/enrich/list_enrich.html:27
 msgid "List of the enrichments"
 msgstr "Liste des enrichissements"
 
-#: pods/templates/videos/enrich/list_enrich.html:52
+#: pods/templates/videos/enrich/list_enrich.html:55
 msgid "Edit the enrichment"
 msgstr "Modifier l'enrichissement"
 
-#: pods/templates/videos/enrich/list_enrich.html:60
+#: pods/templates/videos/enrich/list_enrich.html:63
 msgid "Delete the enrichment"
 msgstr "Supprimer l'enrichissement"
 
-#: pods/templates/videos/extraheadplayer.html:84
+#: pods/templates/videos/extraheadplayer.html:97
 #, python-format
 msgid "Access this content on “%(TITLE_SITE)s” in a new window / tab."
 msgstr ""
@@ -2311,18 +2320,15 @@ msgstr ""
 "souhaitez travailler."
 
 #: pods/templates/videos/ownertools.html:24
-#: pods/templates/videos/videos_list.html:92
 msgid "Edit video information."
 msgstr "Modifier les informations de la vidéo."
 
 #: pods/templates/videos/ownertools.html:28
-#: pods/templates/videos/videos_list.html:95
 msgid "Add subtitle files, contributors, documents to download."
 msgstr "Ajouter des sous-titres, contributeurs, documents à télécharger."
 
 #: pods/templates/videos/ownertools.html:29
 #: pods/templates/videos/ownertools.html:33
-#: pods/templates/videos/videos_list.html:96
 msgid "Completion"
 msgstr "Complétion"
 
@@ -2331,41 +2337,37 @@ msgid "Add contributors."
 msgstr "Ajouter des contributeurs."
 
 #: pods/templates/videos/ownertools.html:36
-#: pods/templates/videos/videos_list.html:98
 msgid "Divide the video into chapters."
 msgstr "Diviser la video en chapitres."
 
 #: pods/templates/videos/ownertools.html:37
-#: pods/templates/videos/videos_list.html:99
 msgid "Chaptering"
 msgstr "Chapitrage"
 
 #: pods/templates/videos/ownertools.html:40
-#: pods/templates/videos/videos_list.html:102
 msgid "Add enrichments to the video."
 msgstr "Ajouter des enrichissements à la vidéo."
 
 #: pods/templates/videos/ownertools.html:41
-#: pods/templates/videos/videos_list.html:103
 msgid "Enrich"
 msgstr "Enrichir"
 
-#: pods/templates/videos/ownertools.html:44
+#: pods/templates/videos/ownertools.html:45
 msgid "Watch the video."
 msgstr "Regarder la vidéo."
 
-#: pods/templates/videos/ownertools.html:45
+#: pods/templates/videos/ownertools.html:46
 msgid "Watch"
 msgstr "Regarder"
 
-#: pods/templates/videos/ownertools.html:48
+#: pods/templates/videos/ownertools.html:50
 msgid "Delete the video."
 msgstr "Supprimer la vidéo."
 
 #: pods/templates/videos/video.html:44 pods/templates/videos/video.html:75
-#: pods/templates/videos/video_chapter.html:184
-#: pods/templates/videos/video_chapter.html:210
-#: pods/templates/videos/video_chapter.html:249
+#: pods/templates/videos/video_chapter.html:175
+#: pods/templates/videos/video_chapter.html:201
+#: pods/templates/videos/video_chapter.html:240
 #: pods/templates/videos/video_enrich.html:182
 #: pods/templates/videos/video_enrich.html:208
 #: pods/templates/videos/video_enrich.html:246
@@ -2380,204 +2382,204 @@ msgstr "Erreur lors de l'envoi des informations."
 msgid "No data could be given."
 msgstr "Aucune données récupérées."
 
-#: pods/templates/videos/video.html:162
+#: pods/templates/videos/video.html:167
 msgid "This video is protected by password, please fill in and click send."
 msgstr ""
 "Cette vidéo est protégée par mot de passe, merci de le renseigner et de "
 "cliquer sur « Envoyer »."
 
-#: pods/templates/videos/video.html:166
+#: pods/templates/videos/video.html:171
 msgid "Password requiered"
 msgstr "Mot de passe requis"
 
-#: pods/templates/videos/video.html:175
+#: pods/templates/videos/video.html:180
 msgid "If you do not have the password or if you have connection problems"
 msgstr ""
 "Si vous n'avez pas le mot de passe ou si vous avez des problèmes de connexion"
 
-#: pods/templates/videos/video.html:196 pods/templates/videos/video.html:198
+#: pods/templates/videos/video.html:201 pods/templates/videos/video.html:203
 msgid "favorite"
 msgstr "favoris"
 
-#: pods/templates/videos/video.html:201 pods/templates/videos/video.html:203
+#: pods/templates/videos/video.html:206 pods/templates/videos/video.html:208
 msgid "Add to your favorites videos."
 msgstr "ajouter à vos vidéos favorites."
 
-#: pods/templates/videos/video.html:212 pods/templates/videos/video.html:214
+#: pods/templates/videos/video.html:217 pods/templates/videos/video.html:219
 msgid "You have already reported this video."
 msgstr "Vous avez déjà signalé cette vidéo."
 
-#: pods/templates/videos/video.html:219 pods/templates/videos/video.html:221
+#: pods/templates/videos/video.html:224 pods/templates/videos/video.html:226
 msgid "Report this video."
 msgstr "Signaler cette vidéo."
 
-#: pods/templates/videos/video.html:233
+#: pods/templates/videos/video.html:238
 msgid "You must be logged in to add this video to your favorites."
 msgstr "Vous devez être connecté pour ajouter cette vidéo à vos favoris."
 
-#: pods/templates/videos/video.html:238
+#: pods/templates/videos/video.html:243
 msgid "You must be logged in to report inappropriate content."
 msgstr "Vous devez être connecté pour signaler cette vidéo."
 
-#: pods/templates/videos/video.html:253
+#: pods/templates/videos/video.html:258
 msgid "Summary"
 msgstr "Résumé"
 
-#: pods/templates/videos/video.html:259
+#: pods/templates/videos/video.html:264
 msgid "Infos"
 msgstr "Informations"
 
-#: pods/templates/videos/video.html:266
+#: pods/templates/videos/video.html:271
 msgid "Downloads"
 msgstr "Télécharger"
 
-#: pods/templates/videos/video.html:274
+#: pods/templates/videos/video.html:279
 msgid "Embed/Share"
 msgstr "Intégrer / Partager"
 
-#: pods/templates/videos/video.html:306 pods/templates/videos/videos.html:67
+#: pods/templates/videos/video.html:311 pods/templates/videos/videos.html:67
 msgid "File missing"
 msgstr "Fichier manquant"
 
-#: pods/templates/videos/video.html:316
+#: pods/templates/videos/video.html:321
 msgid "Number of view(s)"
 msgstr "Nombre de vues"
 
-#: pods/templates/videos/video.html:336
+#: pods/templates/videos/video.html:341
 msgid "Updated on"
 msgstr "Mise en ligne le"
 
-#: pods/templates/videos/video.html:341
+#: pods/templates/videos/video.html:346
 msgid "Contributor(s): writers, directors, editors, designers…"
 msgstr "Contributeur(s) : scénaristes, réalisateurs, éditeurs, concepteurs…"
 
-#: pods/templates/videos/video.html:346
+#: pods/templates/videos/video.html:351
 msgid "send an email"
 msgstr "envoyer un courriel"
 
-#: pods/templates/videos/video.html:354
+#: pods/templates/videos/video.html:359
 msgid "go to his web link"
 msgstr "se rendre à cette adresse web"
 
-#: pods/templates/videos/video.html:368
+#: pods/templates/videos/video.html:373
 msgid "Download the video"
 msgstr "Télécharger la vidéo"
 
-#: pods/templates/videos/video.html:406
+#: pods/templates/videos/video.html:411
 msgid "Social Networks"
 msgstr "Réseaux Sociaux"
 
-#: pods/templates/videos/video.html:418
+#: pods/templates/videos/video.html:423
 msgid "Copy the content of this text box and paste it in the page"
 msgstr "Copiez le contenu de cette zone de texte et collez-le dans la page"
 
-#: pods/templates/videos/video.html:424
+#: pods/templates/videos/video.html:429
 msgid "Video size"
 msgstr "Taille"
 
-#: pods/templates/videos/video.html:435
+#: pods/templates/videos/video.html:440
 msgid "Autoplay"
 msgstr "Lecture automatique"
 
-#: pods/templates/videos/video.html:442
+#: pods/templates/videos/video.html:447
 msgid "Use this link to share the video"
 msgstr "Utilisez ce lien pour partager la vidéo"
 
-#: pods/templates/videos/video.html:448
+#: pods/templates/videos/video.html:453
 msgid "Start video"
 msgstr "Début de la vidéo"
 
-#: pods/templates/videos/video.html:451
+#: pods/templates/videos/video.html:456
 msgid "Check the box to indicate the beginning of playing desired."
 msgstr "Cochez la case pour indiquer le début de lecture souhaité."
 
-#: pods/templates/videos/video.html:481
+#: pods/templates/videos/video.html:486
 msgid "You must be logged in to take notes."
 msgstr "Vous devez être connecté pour prendre des notes."
 
-#: pods/templates/videos/video.html:490
-#: pods/templates/videos/video_chapter.html:374
-#: pods/templates/videos/video_completion.html:513
-#: pods/templates/videos/video_enrich.html:476
+#: pods/templates/videos/video.html:495
+#: pods/templates/videos/video_chapter.html:370
+#: pods/templates/videos/video_completion.html:525
+#: pods/templates/videos/video_enrich.html:483
 msgid "Edit the video"
 msgstr "Modifier la vidéo"
 
 #: pods/templates/videos/video_chapter.html:29
-#: pods/templates/videos/video_chapter.html:330
-#: pods/templates/videos/video_chapter.html:341
+#: pods/templates/videos/video_chapter.html:321
+#: pods/templates/videos/video_chapter.html:333
 msgid "Chaptering the video"
 msgstr "Chapitrer la vidéo "
 
-#: pods/templates/videos/video_chapter.html:193
+#: pods/templates/videos/video_chapter.html:184
 #: pods/templates/videos/video_completion.html:249
 #: pods/templates/videos/video_enrich.html:191
 msgid "Error getting form."
 msgstr "Erreur lors de la récupération du formulaire."
 
-#: pods/templates/videos/video_chapter.html:193
+#: pods/templates/videos/video_chapter.html:184
 #: pods/templates/videos/video_completion.html:249
 #: pods/templates/videos/video_enrich.html:191
 msgid "The form could not be recovered."
 msgstr "Le formulaire n'a pu être rechargé."
 
-#: pods/templates/videos/video_chapter.html:202
+#: pods/templates/videos/video_chapter.html:193
 msgid "Are you sure you want to delete this chapter?"
 msgstr "Etes-vous sûr de vouloir supprimer ce chapitre ?"
 
-#: pods/templates/videos/video_chapter.html:215
+#: pods/templates/videos/video_chapter.html:206
 #: pods/templates/videos/video_completion.html:277
 #: pods/templates/videos/video_enrich.html:213
 msgid "Error during deletion."
 msgstr "Erreur lors de la suppression."
 
-#: pods/templates/videos/video_chapter.html:215
+#: pods/templates/videos/video_chapter.html:206
 #: pods/templates/videos/video_completion.html:277
 #: pods/templates/videos/video_enrich.html:213
 msgid "No data could be deleted."
 msgstr "Aucune données n'a pu être supprimée."
 
-#: pods/templates/videos/video_chapter.html:254
+#: pods/templates/videos/video_chapter.html:245
 #: pods/templates/videos/video_completion.html:315
 #: pods/templates/videos/video_enrich.html:251
 msgid "Error during recording."
 msgstr "Erreur lors de l'enregistrement."
 
-#: pods/templates/videos/video_chapter.html:254
+#: pods/templates/videos/video_chapter.html:245
 #: pods/templates/videos/video_completion.html:315
 #: pods/templates/videos/video_enrich.html:251
 msgid "No data could be stored."
 msgstr "Aucune donnée n'a pu être enregistrée."
 
-#: pods/templates/videos/video_chapter.html:274
-#: pods/templates/videos/video_enrich.html:275 pods/views.py:186
-#: pods/views.py:423 pods/views.py:615 pods/views.py:617 pods/views.py:682
+#: pods/templates/videos/video_chapter.html:265
+#: pods/templates/videos/video_enrich.html:275 pods/views.py:191
+#: pods/views.py:440 pods/views.py:633 pods/views.py:635 pods/views.py:700
 msgid "The changes have been saved."
 msgstr "Les modifications ont été enregistrées."
 
-#: pods/templates/videos/video_chapter.html:286
+#: pods/templates/videos/video_chapter.html:277
 msgid "Please enter a correct start field between 0 and"
 msgstr ""
 "Veuillez renseigner une valeur de début d’enrichissement comprise entre 0 et"
 
-#: pods/templates/videos/video_chapter.html:298
+#: pods/templates/videos/video_chapter.html:289
 msgid "The chapter"
 msgstr "Le chapitre"
 
-#: pods/templates/videos/video_chapter.html:298
+#: pods/templates/videos/video_chapter.html:289
 msgid "starts at the same time."
 msgstr "commence en même temps."
 
-#: pods/templates/videos/video_chapter.html:310
+#: pods/templates/videos/video_chapter.html:301
 #: pods/templates/videos/video_enrich.html:283
 #: pods/templates/videos/video_enrich.html:285
 msgid "Get time from the player"
 msgstr "Récupérer le temps depuis le lecteur"
 
-#: pods/templates/videos/video_chapter.html:366
+#: pods/templates/videos/video_chapter.html:360
 msgid "Add a new chapter"
 msgstr "Ajouter un nouveau chapitre"
 
-#: pods/templates/videos/video_chapter.html:382
+#: pods/templates/videos/video_chapter.html:380
 msgid ""
 "\"Add a new chapter\" allows you to add a new chapter, \"modify\" allows you "
 "to modify it and \"delete\" allows you to remove the chapter."
@@ -2586,7 +2588,7 @@ msgstr ""
 "\"modifier\" permet de le modifier et \"supprimer\" vous permet de le "
 "supprimer."
 
-#: pods/templates/videos/video_chapter.html:383
+#: pods/templates/videos/video_chapter.html:381
 msgid ""
 "Start playback of the video, pause the video and click on \"Get time from "
 "the player\" to fill in the field intitled \"Start time\"."
@@ -2595,17 +2597,17 @@ msgstr ""
 "le temps depuis le lecteur\" pour renseigner automatiquement le champ "
 "\"début du chapitre\"."
 
-#: pods/templates/videos/video_chapter.html:384
+#: pods/templates/videos/video_chapter.html:382
 msgid "The chapters cannot start at the same time."
 msgstr "Les chapitres ne peuvent pas commencer en même temps."
 
-#: pods/templates/videos/video_chapter.html:385
+#: pods/templates/videos/video_chapter.html:383
 msgid "You must save your chapters to view the result."
 msgstr "Vous devez sauvegarder pour visualiser le résultat."
 
 #: pods/templates/videos/video_completion.html:29
-#: pods/templates/videos/video_completion.html:429
-#: pods/templates/videos/video_completion.html:440
+#: pods/templates/videos/video_completion.html:434
+#: pods/templates/videos/video_completion.html:446
 msgid "Completion video"
 msgstr "Complétion de la vidéo "
 
@@ -2682,53 +2684,53 @@ msgstr "Veuillez indiquer un fichier de sous-titre ou de légende."
 msgid "Only “.vtt” format is allowed."
 msgstr "Seul le format « .vtt » est autorisé."
 
-#: pods/templates/videos/video_completion.html:402
+#: pods/templates/videos/video_completion.html:407
 msgid ""
 "There is already a subtitle with this same kind and language in the list."
 msgstr "il y a déjà un fichier de même type et de même langue"
 
-#: pods/templates/videos/video_completion.html:417
+#: pods/templates/videos/video_completion.html:422
 msgid ""
 "There is already a download with this same name of document in the list."
 msgstr "Il y a déjà un document à télécharger portant le même nom."
 
-#: pods/templates/videos/video_completion.html:447
+#: pods/templates/videos/video_completion.html:455
 msgid "Display &quot;Contributor(s)&quot; section"
 msgstr "Afficher la section des contributeurs"
 
-#: pods/templates/videos/video_completion.html:447
+#: pods/templates/videos/video_completion.html:456
 msgid "Contributor(s)"
 msgstr "Contributeurs"
 
-#: pods/templates/videos/video_completion.html:463
+#: pods/templates/videos/video_completion.html:474
 msgid "Add a new contributor"
 msgstr "Ajouter un nouveau contributeur"
 
-#: pods/templates/videos/video_completion.html:469
+#: pods/templates/videos/video_completion.html:479
 msgid "Display &quot;Subtitle(s) and Captions(s) &quot; section"
 msgstr "Afficher la section de sous-titre ou de légende"
 
-#: pods/templates/videos/video_completion.html:469
+#: pods/templates/videos/video_completion.html:479
 msgid "Subtitle(s) and caption(s)"
 msgstr "Sous-titre(s) et légende(s)"
 
-#: pods/templates/videos/video_completion.html:485
+#: pods/templates/videos/video_completion.html:495
 msgid "Add a new subtitle or caption file"
 msgstr "Ajouter un nouveau fichier de sous-titre ou de légende"
 
-#: pods/templates/videos/video_completion.html:489
+#: pods/templates/videos/video_completion.html:499
 msgid "Display &quot; Additional resource(s)&quot; section"
 msgstr "Afficher la section documents complémentaires"
 
-#: pods/templates/videos/video_completion.html:489
+#: pods/templates/videos/video_completion.html:499
 msgid "Additional resource(s)"
 msgstr "Document(s) complémentaire(s)"
 
-#: pods/templates/videos/video_completion.html:504
+#: pods/templates/videos/video_completion.html:514
 msgid "Add a new additional resource"
 msgstr "Ajouter un nouveau document à télécharger"
 
-#: pods/templates/videos/video_completion.html:522
+#: pods/templates/videos/video_completion.html:536
 msgid ""
 "Several web sites allows you to subtitle or caption videos (for example: "
 "Amara)."
@@ -2736,7 +2738,7 @@ msgstr ""
 "Plusieurs sites Web offrent des outils pour sous-titrer ou légender des "
 "vidéos (Par exemple : Amara)."
 
-#: pods/templates/videos/video_completion.html:523
+#: pods/templates/videos/video_completion.html:537
 msgid ""
 "You can add several subtitle or caption files to a single video (for "
 "example, in order to subtitle or caption this video in several languages)."
@@ -2748,7 +2750,7 @@ msgstr ""
 msgid "Those files must be in “.vtt” format."
 msgstr "Ces fichiers doivent être au format « .vtt »."
 
-#: pods/templates/videos/video_completion.html:524
+#: pods/templates/videos/video_completion.html:539
 msgid ""
 "For this purpose, you will need the URL of your video. This URL is a direct "
 "access to this video. Please do not communicate it outside of this site in "
@@ -2759,7 +2761,7 @@ msgstr ""
 "Evitez de la communiquer en dehors de ce site pour éviter tout "
 "téléchargement et utilisation abusive."
 
-#: pods/templates/videos/video_completion.html:528
+#: pods/templates/videos/video_completion.html:543
 msgid ""
 "Your current permissions do not allow you to add subtitle files or documents "
 "to download videos. Please contact us to add these rights."
@@ -2786,112 +2788,112 @@ msgstr ""
 "d'encodage."
 
 #: pods/templates/videos/video_edit.html:24
-#: pods/templates/videos/video_edit.html:279
-#: pods/templates/videos/video_edit.html:314
+#: pods/templates/videos/video_edit.html:274
+#: pods/templates/videos/video_edit.html:309
 msgid "Editing the video"
 msgstr "Modification de la vidéo"
 
-#: pods/templates/videos/video_edit.html:85
-#: pods/templates/videos/video_edit.html:249
+#: pods/templates/videos/video_edit.html:80
+#: pods/templates/videos/video_edit.html:244
 msgid "The file size exceeds the maximum allowed value ({0} {1})."
 msgstr "La taille du fichier dépasse la valeur maximum autorisée ({0} {1})."
 
-#: pods/templates/videos/video_edit.html:130
+#: pods/templates/videos/video_edit.html:125
 msgid "Your data have been successfully sent."
 msgstr "Vos données ont été envoyées avec succès."
 
-#: pods/templates/videos/video_edit.html:132
+#: pods/templates/videos/video_edit.html:127
 msgid "The page will refresh in a few seconds."
 msgstr "La page sera actualisée dans quelques secondes."
 
-#: pods/templates/videos/video_edit.html:207
+#: pods/templates/videos/video_edit.html:202
 msgid "Unable to compute upload progress."
 msgstr "Calcul de la progression du téléversement impossible"
 
-#: pods/templates/videos/video_edit.html:208
+#: pods/templates/videos/video_edit.html:203
 msgid "Upload canceled."
 msgstr "Téléversement annulé."
 
-#: pods/templates/videos/video_edit.html:209
+#: pods/templates/videos/video_edit.html:204
 msgid "Error while uploading or connection dropped."
 msgstr "Erreur durant le téléversement ou connexion interrompue."
 
-#: pods/templates/videos/video_edit.html:247
+#: pods/templates/videos/video_edit.html:242
 msgid "Please select a file to upload."
 msgstr "Veuillez sélectionner un fichier à téléverser."
 
-#: pods/templates/videos/video_edit.html:248
+#: pods/templates/videos/video_edit.html:243
 msgid "File format not supported."
 msgstr "Ce format de fichier n'est pas supporté."
 
-#: pods/templates/videos/video_edit.html:253
+#: pods/templates/videos/video_edit.html:248
 msgid "Please, specify a title."
 msgstr "Veuillez indiquer un titre."
 
-#: pods/templates/videos/video_edit.html:254
+#: pods/templates/videos/video_edit.html:249
 msgid "Your title should contain more than two characters."
 msgstr "Votre titre doit contenir plus de deux caractères."
 
-#: pods/templates/videos/video_edit.html:255
+#: pods/templates/videos/video_edit.html:250
 msgid "Your title should contain less than two hundred fifty characters."
 msgstr "Votre titre doit contenir moins de deux cents cinquante caractères."
 
-#: pods/templates/videos/video_edit.html:258
+#: pods/templates/videos/video_edit.html:253
 msgid "Please, specify a type."
 msgstr "Veuillez spécifier un type."
 
-#: pods/templates/videos/video_edit.html:296
+#: pods/templates/videos/video_edit.html:291
 #: pods/templates/videos/video_player.html:118
 msgid "The video is currently being encoded."
 msgstr "Cette vidéo est en cours d'encodage."
 
-#: pods/templates/videos/video_edit.html:341
+#: pods/templates/videos/video_edit.html:336
 msgid "Upload limit reached."
 msgstr "Limite de téléversement atteinte."
 
-#: pods/templates/videos/video_edit.html:343
+#: pods/templates/videos/video_edit.html:338
 #, python-format
 msgid "You have reached the %(counter)s file per day upload limit."
 msgid_plural "You have reached the %(counter)s files per day upload limit."
 msgstr[0] "Vous avez atteint la limite de %(counter)s téléversement par jour."
 msgstr[1] "Vous avez atteint la limite de %(counter)s téléversements par jour."
 
-#: pods/templates/videos/video_edit.html:344
+#: pods/templates/videos/video_edit.html:339
 msgid "Please come back tomorrow!"
 msgstr "Merci de revenir demain !"
 
-#: pods/templates/videos/video_edit.html:364
+#: pods/templates/videos/video_edit.html:359
 msgid "Save and watch the video"
 msgstr "Enregistrer et voir la vidéo"
 
-#: pods/templates/videos/video_edit.html:373
+#: pods/templates/videos/video_edit.html:368
 msgid "Sending, please wait."
 msgstr "Envoi en cours, merci de patienter."
 
-#: pods/templates/videos/video_edit.html:383
+#: pods/templates/videos/video_edit.html:378
 msgid "The page will refresh after the upload completes."
 msgstr "La page sera actualisée lorsque le téléversement sera terminé."
 
-#: pods/templates/videos/video_edit.html:403
+#: pods/templates/videos/video_edit.html:398
 msgid "Important"
 msgstr ""
 
-#: pods/templates/videos/video_edit.html:409
+#: pods/templates/videos/video_edit.html:404
 msgid "Uploading"
 msgstr "Téléversement"
 
-#: pods/templates/videos/video_edit.html:413
+#: pods/templates/videos/video_edit.html:408
 #, python-format
 msgid "The file size must be lower than %(MAX_UPLOAD_FILE_SIZE)s."
 msgstr "La taille du fichier doit être inférieure à %(MAX_UPLOAD_FILE_SIZE)s."
 
-#: pods/templates/videos/video_edit.html:415
+#: pods/templates/videos/video_edit.html:410
 #, python-format
 msgid "You can upload up to %(MAX_DAILY_USER_UPLOADS)s files per day."
 msgstr ""
 "Vous pouvez téléverser jusqu’à %(MAX_DAILY_USER_UPLOADS)s fichiers par jour."
 
-#: pods/templates/videos/video_edit.html:417
+#: pods/templates/videos/video_edit.html:412
 msgid ""
 "The sending time depends on the size of your file and your upload speed. "
 "This can be quite long."
@@ -2899,7 +2901,7 @@ msgstr ""
 "Le temps d'envoi dépend de la taille de votre fichier et de votre vitesse de "
 "transfert. Cela peut être assez long."
 
-#: pods/templates/videos/video_edit.html:418
+#: pods/templates/videos/video_edit.html:413
 msgid ""
 "While sending your file, do not close your browser until you have received a "
 "message of success or failure."
@@ -2907,27 +2909,27 @@ msgstr ""
 "Pendant l'envoi de votre fichier, ne fermez pas votre navigateur avant "
 "d'avoir reçu un message de succès ou d'échec."
 
-#: pods/templates/videos/video_edit.html:425
+#: pods/templates/videos/video_edit.html:420
 msgid "Mandatory fields"
 msgstr "Champs obligatoires"
 
-#: pods/templates/videos/video_edit.html:429
+#: pods/templates/videos/video_edit.html:424
 msgid "Fields marked with an asterisk are mandatory."
 msgstr "Les champs marqués d'un astérisque sont obligatoires."
 
-#: pods/templates/videos/video_edit.html:435
+#: pods/templates/videos/video_edit.html:430
 msgid "Form fields"
 msgstr "Champs du formulaire"
 
-#: pods/templates/videos/video_edit.html:448
+#: pods/templates/videos/video_edit.html:443
 msgid "You can send an audio or video file."
 msgstr "Vous pouvez envoyer un fichier audio ou vidéo."
 
-#: pods/templates/videos/video_edit.html:449
+#: pods/templates/videos/video_edit.html:444
 msgid "The following formats are supported:"
 msgstr "Les formats suivants sont supportés :"
 
-#: pods/templates/videos/video_edit.html:462
+#: pods/templates/videos/video_edit.html:457
 msgid ""
 "Please choose a title as short and accurate as possible, reflecting the main "
 "subject / context of the content."
@@ -2935,14 +2937,14 @@ msgstr ""
 "Veuillez choisir un titre aussi court et précis que possible, reflétant le "
 "sujet / contexte principal du contenu."
 
-#: pods/templates/videos/video_edit.html:463
+#: pods/templates/videos/video_edit.html:458
 msgid ""
 "You can use the “Description” field below for all additional information."
 msgstr ""
 "Vous pouvez utiliser le champ « Description » ci-après pour toute "
 "information additionnelle."
 
-#: pods/templates/videos/video_edit.html:464
+#: pods/templates/videos/video_edit.html:459
 msgid ""
 "You may add contributors later using the second button of the content "
 "edition toolbar: they will appear in the “Info” tab at the bottom of the "
@@ -2952,15 +2954,15 @@ msgstr ""
 "bouton de la barre d'outil d'édition de contenu : ils apparaîtront dans "
 "l'onglet « Info » sous le lecteur audio / vidéo."
 
-#: pods/templates/videos/video_edit.html:477
+#: pods/templates/videos/video_edit.html:472
 msgid "Enter the date of the event, if applicable, in the AAAA-MM-JJ format."
 msgstr "Entrez la date de l'événement, le cas échéant, au format JJ/MM/AAAA."
 
-#: pods/templates/videos/video_edit.html:490
+#: pods/templates/videos/video_edit.html:485
 msgid "Select an university course as audience target of the content."
 msgstr "Sélectionnez un cursus universitaire comme audience cible du contenu."
 
-#: pods/templates/videos/video_edit.html:491
+#: pods/templates/videos/video_edit.html:486
 msgid ""
 "Choose “None / All” if it does not apply or if all are concerned, or “Other” "
 "for an audience outside the european LMD scheme."
@@ -2968,11 +2970,11 @@ msgstr ""
 "Choisissez « Aucun / Tous » si cela ne s'applique pas ou si tous sont "
 "concernés, ou « Autres » pour une audience en dehors du schéma européen LMD."
 
-#: pods/templates/videos/video_edit.html:504
+#: pods/templates/videos/video_edit.html:499
 msgid "Select the main language used in the content."
 msgstr "Sélectionnez la langue principale employée dans le contenu."
 
-#: pods/templates/videos/video_edit.html:517
+#: pods/templates/videos/video_edit.html:512
 msgid ""
 "In this field you can describe your content, add all needed related "
 "information, and format the result using the toolbar."
@@ -2980,11 +2982,11 @@ msgstr ""
 "Dans ce champ vous pouvez décrire votre contenu, préciser toute information "
 "utile, et formater le résultat en utilisant la barre d'outils."
 
-#: pods/templates/videos/video_edit.html:544
+#: pods/templates/videos/video_edit.html:539
 msgid "Select the type of your content."
 msgstr "Sélectionnez le type de votre contenu."
 
-#: pods/templates/videos/video_edit.html:546
+#: pods/templates/videos/video_edit.html:541
 msgid ""
 "If the type you wish does not appear in the list, please temporary select "
 "“Other” and"
@@ -2992,25 +2994,26 @@ msgstr ""
 "Si le type souhaité n'apparaît pas dans la liste, veuillez sélectionner "
 "temporairement « Autre » et"
 
-#: pods/templates/videos/video_edit.html:546
-#: pods/templates/videos/video_edit.html:562
-#: pods/templates/videos/video_edit.html:581
-#: pods/templates/videos/video_edit.html:598
+#: pods/templates/videos/video_edit.html:541
+#: pods/templates/videos/video_edit.html:557
+#: pods/templates/videos/video_edit.html:576
+#: pods/templates/videos/video_edit.html:594
+#: pods/templates/videos/videos_iframe.html:37
 msgid "Click to open in a new window / tab."
 msgstr "Cliquez pour ouvrir dans une nouvelle fenêtre / un nouvel onglet."
 
-#: pods/templates/videos/video_edit.html:546
-#: pods/templates/videos/video_edit.html:562
-#: pods/templates/videos/video_edit.html:581
-#: pods/templates/videos/video_edit.html:598
+#: pods/templates/videos/video_edit.html:541
+#: pods/templates/videos/video_edit.html:557
+#: pods/templates/videos/video_edit.html:576
+#: pods/templates/videos/video_edit.html:594
 msgid "explain us your needs."
 msgstr "expliquez-nous vos attentes."
 
-#: pods/templates/videos/video_edit.html:560
+#: pods/templates/videos/video_edit.html:555
 msgid "Select the discipline to which your content belongs."
 msgstr "Sélectionnez la discipline à laquelle appartient votre contenu."
 
-#: pods/templates/videos/video_edit.html:562
+#: pods/templates/videos/video_edit.html:557
 msgid ""
 "If the discipline you wish does not appear in the list, please select "
 "nothing and"
@@ -3018,28 +3021,28 @@ msgstr ""
 "Si la discipline souhaitée n'apparaît pas dans la liste, veuillez ne rien "
 "sélectionner et"
 
-#: pods/templates/videos/video_edit.html:564
-#: pods/templates/videos/video_edit.html:583
-#: pods/templates/videos/video_edit.html:599
+#: pods/templates/videos/video_edit.html:559
+#: pods/templates/videos/video_edit.html:578
+#: pods/templates/videos/video_edit.html:596
 msgid ""
 "Hold down \"Control\", or \"Command\" on a Mac, to select more than one."
 msgstr ""
 "Maintenez appuyé « Control » (ou « Commande » sur un Mac) pour en "
 "sélectionner plusieurs."
 
-#: pods/templates/videos/video_edit.html:578
+#: pods/templates/videos/video_edit.html:573
 msgid "Select the channel in which you want your content to appear."
 msgstr ""
 "Sélectionnez la chaîne dans laquelle vous voulez faire apparaître votre "
 "contenu."
 
-#: pods/templates/videos/video_edit.html:579
+#: pods/templates/videos/video_edit.html:574
 msgid "Themes related to this channel will appear in the “Themes” list below."
 msgstr ""
 "Les thèmes liés à cette chaîne apparaîtront dans la liste « Thèmes » ci-"
 "dessous."
 
-#: pods/templates/videos/video_edit.html:581
+#: pods/templates/videos/video_edit.html:576
 msgid ""
 "If the channel you wish does not appear in the list, please select nothing "
 "and"
@@ -3047,12 +3050,12 @@ msgstr ""
 "Si la chaîne souhaitée n'apparaît pas dans la liste, veuillez ne rien "
 "sélectionner et"
 
-#: pods/templates/videos/video_edit.html:596
+#: pods/templates/videos/video_edit.html:591
 msgid "Select the theme in which you want your content to appear."
 msgstr ""
 "Sélectionnez le thème dans lequel vous voulez faire apparaître votre contenu."
 
-#: pods/templates/videos/video_edit.html:597
+#: pods/templates/videos/video_edit.html:593
 msgid ""
 "If the theme you wish does not appear in the list and if you are an owner of "
 "the related channel, you can edit this channel to create it (use your user "
@@ -3062,11 +3065,11 @@ msgstr ""
 "propriétaire de la chaîne concernée, vous pouvez éditer cette chaîne pour le "
 "créer (utilisez votre menu utilisateur en haut à droite de la page)."
 
-#: pods/templates/videos/video_edit.html:598
+#: pods/templates/videos/video_edit.html:594
 msgid "If you do not own the channel, please select nothing and"
 msgstr "Si vous n'êtes pas propriétaire de la chaîne, ne sélectionnez rien et"
 
-#: pods/templates/videos/video_edit.html:613
+#: pods/templates/videos/video_edit.html:610
 msgid ""
 "In “Draft mode”, the content shows nowhere and nobody else but you can see "
 "it."
@@ -3074,18 +3077,18 @@ msgstr ""
 "En mode « Brouillon », le contenu n’apparaît nulle part et personne d’autre "
 "que vous ne le voit."
 
-#: pods/templates/videos/video_edit.html:626
-#: pods/templates/videos/video_edit.html:641
+#: pods/templates/videos/video_edit.html:623
+#: pods/templates/videos/video_edit.html:638
 msgid "If you don't select “Draft mode”,"
 msgstr "Si vous ne sélectionnez pas le mode « Brouillon »,"
 
-#: pods/templates/videos/video_edit.html:627
+#: pods/templates/videos/video_edit.html:624
 msgid "you can restrict the content access to only people belonging to"
 msgstr ""
 "vous pouvez restreindre l’accès à votre contenu aux seules personnes "
 "appartenant à"
 
-#: pods/templates/videos/video_edit.html:642
+#: pods/templates/videos/video_edit.html:639
 msgid ""
 "you can add a password which will be asked to anybody willing to watch your "
 "content."
@@ -3093,11 +3096,11 @@ msgstr ""
 "vous pouvez ajouter un mot de passe qui sera demandé à toute personne "
 "souhaitant visionner votre contenu."
 
-#: pods/templates/videos/video_edit.html:650
+#: pods/templates/videos/video_edit.html:647
 msgid "Keywords"
 msgstr "Mots-clés"
 
-#: pods/templates/videos/video_edit.html:655
+#: pods/templates/videos/video_edit.html:652
 msgid ""
 "Please try to add only relevant keywords that can be useful to other users."
 msgstr ""
@@ -3145,20 +3148,20 @@ msgid ", please change start and/or end values."
 msgstr ", veuillez modifier les valeurs de début et/ou de fin."
 
 #: pods/templates/videos/video_enrich.html:434
-#: pods/templates/videos/video_enrich.html:445
+#: pods/templates/videos/video_enrich.html:446
 msgid "Enrich video"
 msgstr "Enrichir la vidéo"
 
-#: pods/templates/videos/video_enrich.html:468
+#: pods/templates/videos/video_enrich.html:473
 msgid "Add a new enrichment"
 msgstr "Ajouter un nouvel enrichissement"
 
-#: pods/templates/videos/video_enrich.html:484
+#: pods/templates/videos/video_enrich.html:493
 msgid ""
 "The title fields is required and must contains from 2 to 100 characters."
 msgstr "Le titre est obligatoire et doit contenir entre 2 et 100 caractères."
 
-#: pods/templates/videos/video_enrich.html:485
+#: pods/templates/videos/video_enrich.html:494
 msgid ""
 "The fields \"Start\" and \"End\" must contain an indication value in "
 "seconds. Start playback of the video, pause the video and click on \"Get "
@@ -3171,11 +3174,11 @@ msgstr ""
 "l'enrichissement\". Faites de même pour renseigner le champ \"Fin de "
 "l'enrichissement\"."
 
-#: pods/templates/videos/video_enrich.html:486
+#: pods/templates/videos/video_enrich.html:495
 msgid "You cannot overlap enrichments."
 msgstr "Les enrichissements ne peuvent se chevaucher."
 
-#: pods/templates/videos/video_enrich.html:487
+#: pods/templates/videos/video_enrich.html:496
 msgid "You must save your enrichments to view the result."
 msgstr "Vous devez sauvegarder pour visualiser le résultat."
 
@@ -3197,18 +3200,6 @@ msgstr "moins"
 msgid "Submit"
 msgstr "Envoyer"
 
-#: pods/templates/videos/videos_list.html:48
-msgid "This content is only accessible to authenticated users."
-msgstr "Ce contenu est uniquement accessible aux utilisateurs authentifiés."
-
-#: pods/templates/videos/videos_list.html:51
-msgid "This content is password protected."
-msgstr "Ce contenu est protégé par mot de passe."
-
-#: pods/templates/videos/videos_list.html:57
-msgid "This content is chaptered."
-msgstr "Ce contenu est chapitré."
-
 #: pods/templates/videos/videos_list.html:71
 msgid "This content is offline (draft mode activated)."
 msgstr "Ce contenu n'est pas en ligne (mode brouillon activé)."
@@ -3217,43 +3208,43 @@ msgstr "Ce contenu n'est pas en ligne (mode brouillon activé)."
 msgid "This content is online (draft mode desactivated)."
 msgstr "Ce contenu est en ligne (mode brouillon désactivé)."
 
-#: pods/templatetags/list.py:193 pods/templatetags/list.py:204
+#: pods/templatetags/list.py:195 pods/templatetags/list.py:206
 msgid "New"
 msgstr "Nouveau"
 
-#: pods/translation.py:27 pods/translation.py:32 pods/translation.py:37
+#: pods/translation.py:28 pods/translation.py:34 pods/translation.py:40
 msgid "-- sorry, no translation provided --"
 msgstr "-- désolé, aucune traduction disponible --"
 
-#: pods/views.py:164
+#: pods/views.py:169
 msgid "You cannot edit this channel."
 msgstr "Vous ne pouvez pas modifier cette chaîne."
 
-#: pods/views.py:408 pods/views.py:1440
+#: pods/views.py:425 pods/views.py:1460
 msgid "You cannot watch this video."
 msgstr "Vous ne pouvez pas regarder cette vidéo."
 
-#: pods/views.py:452
+#: pods/views.py:469
 msgid "Incorrect password"
 msgstr "Mot de passe incorrect"
 
-#: pods/views.py:512
+#: pods/views.py:529
 msgid "The video has been added to your favorites."
 msgstr "La vidéo a été ajoutée à vos vidéos favorites."
 
-#: pods/views.py:517
+#: pods/views.py:534
 msgid "The video has been removed from your favorites."
 msgstr "La vidéo a été supprimée de vos vidéos favorites."
 
-#: pods/views.py:526 pods/views.py:599 pods/views.py:621
+#: pods/views.py:543 pods/views.py:617 pods/views.py:639
 msgid "You cannot acces this page."
 msgstr "Vous ne pouvez pas accéder à cette page."
 
-#: pods/views.py:537
+#: pods/views.py:555
 msgid "Video report confirmation"
 msgstr "Confirmation de signalement de vidéo"
 
-#: pods/views.py:539
+#: pods/views.py:557
 #, python-format
 msgid ""
 "\n"
@@ -3272,7 +3263,7 @@ msgstr ""
 "Cordialement.\n"
 "L'équipe Pod."
 
-#: pods/views.py:544
+#: pods/views.py:562
 #, python-format
 msgid ""
 "<p>You just report the video: \"%(title)s\" with this comment:<br/> "
@@ -3283,11 +3274,11 @@ msgstr ""
 "<br/> \"%(comment)s\".</p><p>Un courriel vient de nous être envoyé et votre "
 "signalement enregistré.</p><p>Cordialement</p><p>L'équipe Pod</p>"
 
-#: pods/views.py:554
+#: pods/views.py:572
 msgid "A video has just been reported."
 msgstr "Une vidéo vient d'être signalée."
 
-#: pods/views.py:556
+#: pods/views.py:574
 #, python-format
 msgid ""
 "The video intitled \"%(video_title)s\" has just been reported by "
@@ -3311,7 +3302,7 @@ msgstr ""
 "%(owner_email)s>.\n"
 "Vidéo mise en ligne le : %(video_date_added)s.\n"
 
-#: pods/views.py:570
+#: pods/views.py:588
 #, python-format
 msgid ""
 "<p>The video intitled \"%(video_title)s\" has just been reported by "
@@ -3332,58 +3323,58 @@ msgstr ""
 "href=\"mailto:%(owner_email)s\">%(owner_email)s&gt;</a>.<br/>Vidéo mise en "
 "ligne le : %(video_date_added)s.</p>"
 
-#: pods/views.py:590
+#: pods/views.py:608
 msgid "This video has been reported."
 msgstr "La vidéo a été signalée."
 
-#: pods/views.py:645
+#: pods/views.py:663
 msgid "You cannot edit this video."
 msgstr "Vous ne pouvez pas éditer cette vidéo."
 
-#: pods/views.py:740 pods/views.py:774 pods/views.py:908 pods/views.py:1039
+#: pods/views.py:760 pods/views.py:794 pods/views.py:928 pods/views.py:1059
 msgid "You cannot complement this video."
 msgstr "Vous ne pouvez pas compléter cette vidéo."
 
-#: pods/views.py:832 pods/views.py:965 pods/views.py:1098
+#: pods/views.py:852 pods/views.py:985 pods/views.py:1118
 msgid "Please correct errors"
 msgstr "Veuillez corriger les erreurs."
 
-#: pods/views.py:1174
+#: pods/views.py:1194
 msgid "You cannot chapter this video."
 msgstr "Vous ne pouvez pas chapitrer cette vidéo."
 
-#: pods/views.py:1220 pods/views.py:1338
+#: pods/views.py:1240 pods/views.py:1358
 msgid "Please correct errors."
 msgstr "Veuillez corriger les erreurs."
 
-#: pods/views.py:1291
+#: pods/views.py:1311
 msgid "You cannot enrich this video."
 msgstr "Vous ne pouvez pas enrichir cette vidéo."
 
-#: pods/views.py:1402
+#: pods/views.py:1422
 msgid "You cannot delete this video."
 msgstr "Vous ne pouvez pas supprimer cette vidéo."
 
-#: pods/views.py:1418
+#: pods/views.py:1438
 msgid "The video has been deleted."
 msgstr "La vidéo a été supprimée."
 
-#: pods/views.py:1625
+#: pods/views.py:1655
 msgid "Mediapath should be indicated."
 msgstr "MediaPath doit être indiqué."
 
-#: pods/views.py:1649
+#: pods/views.py:1679
 msgid ""
 "Your publication is saved. Adding it to your videos will be in a few minutes."
 msgstr ""
 "Votre publication est enregistrée. Son ajout à vos vidéos se fera dans "
 "quelques minutes."
 
-#: pods/views.py:1706
+#: pods/views.py:1736
 msgid "Recording"
 msgstr "En cours d'enregistrement"
 
-#: pods/views.py:1708
+#: pods/views.py:1738
 #, python-format
 msgid ""
 "Hello, \n"
@@ -3409,7 +3400,7 @@ msgstr ""
 "\n"
 "Cordialement"
 
-#: pods/views.py:1712
+#: pods/views.py:1742
 #, python-format
 msgid ""
 "Hello, <p>a new mediacourse has just be added on %(title_site)s from the "
@@ -3423,7 +3414,7 @@ msgstr ""
 "%(link_url)s</a><br/><i>Si le lien n'est pas actif, il faut le copier-coller "
 "dans la barre d'adresse de votre navigateur.</i><p><p>Cordialement</p>"
 
-#: pods/views.py:1719
+#: pods/views.py:1749
 msgid "New mediacourse added."
 msgstr "Nouveaux médiacours ajoutés."
 

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -2744,6 +2744,10 @@ msgstr ""
 "Vous pouvez ajouter plusieurs fichiers de sous-titre ou de légende pour une "
 "même vidéo (par exemple, vous pouvez sous-titrer en plusieurs langues)."
 
+#: pods/templates/videos/video_completion.html:538
+msgid "Those files must be in “.vtt” format."
+msgstr "Ces fichiers doivent être au format « .vtt »."
+
 #: pods/templates/videos/video_completion.html:524
 msgid ""
 "For this purpose, you will need the URL of your video. This URL is a direct "

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -2200,8 +2200,8 @@ msgstr "Supprimer le chapitre"
 #: pods/templates/videos/completion/contributor/form_contributor.html:27
 #: pods/templates/videos/completion/download/form_download.html:28
 #: pods/templates/videos/completion/subtitle/form_subtitle.html:28
-msgid "Your form contains errors"
-msgstr "Le formulaire contiens des erreurs."
+msgid "Your form contains errors:"
+msgstr "Le formulaire contient des erreurs :"
 
 #: pods/templates/videos/completion/contributor/form_contributor.html:43
 #: pods/templates/videos/completion/download/form_download.html:44

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -2756,7 +2756,7 @@ msgid ""
 msgstr ""
 "Sur ce site, vous aurez besoin de l'URL de votre vidéo. Vous la trouverez ci-"
 "dessous. Veuillez noter que cette URL est un accès direct à votre vidéo. "
-"Eviter de la communiquer en dehors de ce site pour éviter tout "
+"Evitez de la communiquer en dehors de ce site pour éviter tout "
 "téléchargement et utilisation abusive."
 
 #: pods/templates/videos/video_completion.html:528


### PR DESCRIPTION
This branch:

- prevents the use of “.srt” files as caption and subtitles files, as video.js has stopped using them after v4.11 ([more info here](https://github.com/videojs/video.js/issues/1956#issuecomment-85617607)),
- repairs the possibility to modify the subtitle / caption text size via LESS / CSS (broken by vjs 4.12).


> Note: existing caption or subtitles using “.srt” files will silently fail. Existing Pod instances using such files will have to replace them by “.vtt” files.
