### PR TITLE
Bugfix : update file tested in subtitle completion test

### DIFF
--- a/pod_project/pods/tests/tests_views.py
+++ b/pod_project/pods/tests/tests_views.py
@@ -1244,7 +1244,7 @@ class Video_completion_TestView(TestCase):
         folder, created = Folder.objects.get_or_create(
             name="remi", owner=pod.owner, level=0)
         upc_document, created = Image.objects.get_or_create(
-            folder=folder, name="test")
+            folder=folder, name="test.vtt")
         upc_document, created = Image.objects.get_or_create(
             folder=folder, name="test2")
 


### PR DESCRIPTION
Since the check of input subtitles files (only .vtt) the previous tested file in Video_completion_TestView class are obsolete. Now the tested file have a correct .vtt extension.