### PR TITLE
first celery integration

### DIFF
--- a/pod_project/pod_project/__init__.py
+++ b/pod_project/pod_project/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, unicode_literals
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ['celery_app']

--- a/pod_project/pod_project/celery.py
+++ b/pod_project/pod_project/celery.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+import os
+
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pod_project.settings")
+
+from django.conf import settings  # noqa
+
+app = Celery(settings.CELERY_NAME, backend=settings.CELERY_BACKEND, broker=settings.CELERY_BROKER)
+
+# Using a string here means the worker will not have to
+# pickle the object when using Windows.
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))

--- a/pod_project/pod_project/settings_local-sample.py
+++ b/pod_project/pod_project/settings_local-sample.py
@@ -396,3 +396,9 @@ RECORDER_SALT = 'a.string.used.as.salt'
 # Optional settings for test:
 #   if set it's used for download and encoding test
 # HTTP_PROXY = 'http://localhost:3128/'
+
+# Encode with Celery
+CELERY_TO_ENCODE = False
+CELERY_NAME = "pod_project"
+CELERY_BACKEND = "amqp"
+CELERY_BROKER = "amqp://guest@localhost//"

--- a/pod_project/pod_project/tasks.py
+++ b/pod_project/pod_project/tasks.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, unicode_literals
+from celery import shared_task
+
+
+@shared_task(bind=True)
+def task_start_encode(self, video):
+    print "START ENCODE VIDEO ID %s" % video.id
+    from core.utils import encode_video
+    encode_video(video)

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -45,6 +45,7 @@ import logging
 logger = logging.getLogger(__name__)
 import unicodedata
 import json
+from pod_project.tasks import task_start_encode
 
 ES_URL = getattr(settings, 'ES_URL', ['http://127.0.0.1:9200/'])
 
@@ -471,7 +472,10 @@ def launch_encode(sender, instance, created, **kwargs):
         instance.to_encode = False
         instance.encoding_in_progress = True
         instance.save()
-        start_encode(instance)
+        if settings.CELERY_TO_ENCODE:
+            task_start_encode.delay(instance)
+        else:
+            start_encode(instance)
 
 
 def start_encode(video):

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ virtualenv==12.0.7
 virtualenvwrapper==4.3.2
 coverage==3.7.1
 sqlparse==0.2.1
+celery==3.1.24


### PR DESCRIPTION
Bonjour,

Ci-joint un premier pull request d'une intégration simple de Celery dans pod, qui permet donc la séparation de l'encodage de l'application web.

Je vous invite à faire des tests de votre côté avant de merger la pull request, car nous sommes sous ubuntu et non debian. Et j'ai créé la pull request en faisant des diffs/apply de notre fork, donc on se sait jamais.

La version utilisée est encore la version stable 3.1 car nous n'avons pas encore eu le temps de nous pencher sur la nouvelle version 4.0.

Les 3 paramètres du fichier de configuration concernés sont donc 
Pour activer l'encodage via Celery
CELERY_TO_ENCODE = True 
Pour définir le nom du projet (ne devrait pas changer)
CELERY_NAME = "pod_project"
Pour définir le type de backend (ici rabbitmq)
CELERY_BACKEND = "amqp"
Pour définir le broker (ici un rabbitmq local)
CELERY_BROKER = "amqp://guest@localhost//"

Au niveau du backend et du broker, il est également possible d'utiliser redis par exemple.

Pour exécuter Celery manuellement, il suffit d'exécuter la commande dans le répertoire du projet
celery -A pod_project worker -l info

Il est également possible de démarrer celery via systemd ou init (http://docs.celeryproject.org/en/3.1/tutorials/daemonizing.html)

Pour lancer l'encodage sur d'autres serveurs, il faut pour chaque serveur d'encodage
* Déployer le code de l'application (mais sans lancer le serveur wsgi)
* Exécuter celery via systemd ou init
* Les différents serveurs se débrouillent pour se répartir la charge via rabbitmq

A titre informatif, voici notre fichier de configuration Celery pour la séparation de l'encodage, à adapter évidemment (/etc/default/celery)

CELERYD_NODES="worker1"
DJANGO_SETTINGS_MODULE="pod_project.settings.preprod"
CELERY_BIN="/home/django/.virtualenvs/pod/bin/celery"
CELERY_APP="pod_project"
CELERYD_CHDIR="/home/django/podcast-pprd.unistra.fr/current"
CELERYD_OPTS="--time-limit=86400 --concurrency=1 --maxtasksperchild=1"
CELERYD_LOG_FILE="/var/log/celery/%N.log"
CELERYD_PID_FILE="/var/run/celery/%N.pid"
CELERYD_USER="django"
CELERYD_GROUP="di"
CELERY_CREATE_DIRS=1
CELERYD_LOG_LEVEL="INFO"

Ce patch permet de remplir les objectifs de stabilité et de rapidité que nous attendions.
Les CPU des serveurs web ne sont ainsi plus surchargés par ffmpeg.
On peut facilement rajouter des workers Celery si on a besoin de plus de machine d'encodage.

Du coup, on a le fonctionnement suivant en preprod
* un serveur rabbitmq pour gérer la file d'attente des jobs
* 2 serveurs web qui servent l'application et qui crééent les jobs dans rabbitmq via le client celery
* 2 serveurs d'encodage qui écoutent la file d'attente via les workers celery et qui lancent les jobs

Cordialement

Morgan Bohn











