### PR TITLE
use prefetch related to improved requests

### DIFF
--- a/pod_project/pods/context_processors.py
+++ b/pod_project/pods/context_processors.py
@@ -47,6 +47,9 @@ def items_menu_header(request):
             output_field=IntegerField(),
         ))),
         'OWNERS': User.objects.filter(
-            pod__in=Pod.objects.filter(is_draft=False, encodingpods__gt=0).distinct()
-        ).order_by('last_name').distinct().prefetch_related("userprofile")
+            pod__is_draft=False, pod__encodingpods__gt=0
+        ).order_by('last_name').annotate(
+            video_count=Count(Case(
+                When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
+                output_field=IntegerField()))).prefetch_related("userprofile")
     }

--- a/pod_project/pods/context_processors.py
+++ b/pod_project/pods/context_processors.py
@@ -6,7 +6,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -31,5 +31,5 @@ def items_menu_header(request):
         'TYPES': Type.objects.all(),
         'DISCIPLINES': Discipline.objects.all(),
         # User.objects.all()
-        'OWNERS': User.objects.filter(pod__in=Pod.objects.filter(is_draft=False, encodingpods__gt=0).distinct()).order_by('last_name').distinct()
+        'OWNERS': User.objects.filter(pod__in=Pod.objects.filter(is_draft=False, encodingpods__gt=0).distinct()).order_by('last_name').distinct().prefetch_related("userprofile")
     }

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -101,12 +101,6 @@ class Channel(models.Model):
     def get_absolute_url(self):
         return reverse('channel', kwargs={'slug_c': self.slug})
 
-    def video_count(self):
-        return self.pod_set.filter(is_draft=False, encodingpods__gt=0).distinct().count()
-        # return Video.objects.filter(categories__in=self.categories.all()).filter(is_draft=False).count()
-        # return self.video_set.all().count()
-    video_count.short_description = _('count')
-
 
 @python_2_unicode_compatible
 class Theme(models.Model):
@@ -142,12 +136,6 @@ class Theme(models.Model):
     def get_absolute_url(self):
         return reverse('theme', kwargs={'slug_c': self.channel.slug, 'slug_t': self.slug})
 
-    def video_count(self):
-        return self.pod_set.filter(is_draft=False, encodingpods__gt=0).distinct().count()
-        # return Video.objects.filter(categories__in=self.categories.all()).filter(is_draft=False).count()
-        # return self.video_set.all().count()
-    video_count.short_description = _('count')
-
 
 @python_2_unicode_compatible
 class Type(models.Model):
@@ -178,12 +166,6 @@ class Type(models.Model):
     def __unicode__(self):
         return "%s" % (self.title)
 
-    def video_count(self):
-        return self.pod_set.filter(is_draft=False, encodingpods__gt=0).distinct().count()
-        # return Video.objects.filter(categories__in=self.categories.all()).filter(is_draft=False).count()
-        # return self.video_set.all().count()
-    video_count.short_description = _('count')
-
 
 @python_2_unicode_compatible
 class Discipline(models.Model):
@@ -213,12 +195,6 @@ class Discipline(models.Model):
 
     def __unicode__(self):
         return "%s" % (self.title)
-
-    def video_count(self):
-        return self.pod_set.filter(is_draft=False, encodingpods__gt=0).distinct().count()
-        # return Video.objects.filter(categories__in=self.categories.all()).filter(is_draft=False).count()
-        # return self.video_set.all().count()
-    video_count.short_description = _('count')
 
 
 def get_nextautoincrement(mymodel):
@@ -403,7 +379,7 @@ class Pod(Video):
         for encoding in self.encodingpods_set.all():
             if encoding.encodingFile:
                 encoding.encodingFile.delete()
-        
+
         # on supprime le fichier source
         if REMOVE_VIDEO_FILE_SOURCE_ON_DELETE:
             self.video.delete()

--- a/pod_project/pods/templates/owners/owners_list.html
+++ b/pod_project/pods/templates/owners/owners_list.html
@@ -33,9 +33,9 @@ voir http://www.gnu.org/licenses/
             {% endif %}
     		</span>
 		{% if owner.get_full_name %}
-            <h5>{{owner.get_full_name|safe|striptags|truncatechars:32}} ({% video_count owner %})</h5>
+            <h5>{{owner.get_full_name|safe|striptags|truncatechars:32}} ({{ owner.video_count }})</h5>
 		{% else %}
-            <h5>{{owner.username|safe|striptags|truncatechars:32}} ({% video_count owner %})</h5>
+            <h5>{{owner.username|safe|striptags|truncatechars:32}} ({{ owner.video_count }})</h5>
 		{% endif %}
 		</a>
 	</div>
@@ -44,4 +44,3 @@ voir http://www.gnu.org/licenses/
 <div class="pager">
     {% block pagination %} {% pagination owners %}{% endblock %}
 </div>
-

--- a/pod_project/pods/templates/videos/video.html
+++ b/pod_project/pods/templates/videos/video.html
@@ -25,7 +25,7 @@ voir http://www.gnu.org/licenses/
 {% block bootstrap3_title %}{{ video.title }}{% endblock bootstrap3_title %}
 
 {% block bootstrap3_extra_head %}
-    
+
     {% include 'videos/extraheadplayer.html' %}
 <script>
     $(document).on('submit', 'form#video_report_form', function (event) {
@@ -311,7 +311,7 @@ $(document).on('click', '#button_video_favorite', function (event) {
                                     <img src="{% static 'filer/icons/image_48x48.png' %}" alt="{% trans 'File missing' %}" class="img-rounded" />
                                 {% endif %}
                                     {{ video.owner.get_full_name }}
-                                    <span class="badge">{% video_count video.owner%}</span>
+                                    <span class="badge">{% video_count video.owner %}</span>
                                 </a>
                             </li>
                             <li class="list-group-item">
@@ -324,7 +324,7 @@ $(document).on('click', '#button_video_favorite', function (event) {
                                 {% trans 'Type' %} :
                                 <a href="{% url 'videos' %}?type={{ video.type.slug }}" title="{{ video.type.title }}" {% if request.GET.is_iframe %}target="_blank"{% endif %}>
                                     {{ video.type.title }}
-                                    <span class="badge">{{ video.type.video_count }}</span>
+                                    <span class="badge">{% video_count video.type %}</span>
                                 </a>
                             </li>
                         {% if video.discipline.all %}
@@ -332,7 +332,7 @@ $(document).on('click', '#button_video_favorite', function (event) {
                                 {% for disc in video.discipline.all %}
                                     <a href="{% url 'videos' %}?discipline={{ disc.slug }}" title="{{ disc.title }}" {% if request.GET.is_iframe %}target="_blank"{% endif %}>
                                         {{ disc.title }}
-                                        <span class="badge">{{ disc.video_count }}</span>
+                                        <span class="badge">{% video_count disc %}</span>
                                     </a>
                                 {% endfor %}
                             </li>

--- a/pod_project/pods/templatetags/list.py
+++ b/pod_project/pods/templatetags/list.py
@@ -153,9 +153,10 @@ def pagination(context, cl, index=1):
 @register.simple_tag()
 def user_menu(filter, queryset_user):
     html = ""
-    for user in queryset_user.filter(last_name__iregex=r'^%s+' % filter):
+    for user in queryset_user.filter(last_name__iregex=r'^%s+' % filter).prefetch_related('pod_set'):
+        pod_set_count = len({ p for p in user.pod_set.all() if p.is_draft == False })
         html += "<li class=\"subItem\"><a href=\"%s%s\">%s %s (%s)</a></li>" % (reverse(
-            'videos'), "?owner=%s" % user.username, user.last_name, user.first_name, user.pod_set.filter(is_draft=False, encodingpods__gt=0).distinct().count())
+            'videos'), "?owner=%s" % user.username, user.last_name, user.first_name, pod_set_count)
     return html
 
 

--- a/pod_project/pods/templatetags/list.py
+++ b/pod_project/pods/templatetags/list.py
@@ -153,9 +153,7 @@ def pagination(context, cl, index=1):
 @register.simple_tag()
 def user_menu(filter, queryset_user):
     html = ""
-    for user in queryset_user.filter(last_name__iregex=r'^%s+' % filter).prefetch_related('pod_set').annotate(
-        video_count=Count(Case(When(pod__is_draft=False, pod__encodingpods__gt=0, then=1), output_field=IntegerField()))):
-
+    for user in queryset_user.filter(last_name__iregex=r'^%s+' % filter):
         html += "<li class=\"subItem\"><a href=\"%s%s\">%s %s (%s)</a></li>" % (reverse(
             'videos'), "?owner=%s" % user.username, user.last_name, user.first_name, user.video_count)
     return html

--- a/pod_project/pods/tests/tests_models.py
+++ b/pod_project/pods/tests/tests_models.py
@@ -33,6 +33,7 @@ from django.test.client import RequestFactory
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from datetime import date, timedelta
 import os
+from django.db.models import Count, Case, When, IntegerField
 # Create your tests here.
 """
     test the channel
@@ -62,7 +63,10 @@ class ChannelTestCase(TestCase):
 	"""
 
     def test_Channel_null_attribut(self):
-        channel = Channel.objects.get(title="ChannelTest1")
+        channel = Channel.objects.annotate(video_count=Count(Case(
+            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
+            output_field=IntegerField(),
+        ))).get(title="ChannelTest1")
         self.assertEqual(channel.visible, False)
         self.assertFalse(channel.slug == slugify("blabla"))
         self.assertEqual(channel.color, None)
@@ -70,7 +74,7 @@ class ChannelTestCase(TestCase):
         self.assertEqual(channel.headband, None)
         self.assertEqual(channel.style, None)
         self.assertEqual(channel.__unicode__(), 'ChannelTest1')
-        self.assertEqual(channel.video_count(), 0)
+        self.assertEqual(channel.video_count, 0)
         self.assertEqual(channel.get_absolute_url(), "/" + channel.slug + "/")
 
         print (
@@ -81,7 +85,10 @@ class ChannelTestCase(TestCase):
 	"""
 
     def test_Channel_with_attributs(self):
-        channel = Channel.objects.get(title="ChannelTest2")
+        channel = Channel.objects.annotate(video_count=Count(Case(
+            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
+            output_field=IntegerField(),
+        ))).get(title="ChannelTest2")
         self.assertEqual(channel.visible, True)
         channel.color = "Blue"
         self.assertEqual(channel.color, "Blue")
@@ -89,7 +96,7 @@ class ChannelTestCase(TestCase):
         self.assertEqual(channel.headband, None)
         self.assertEqual(channel.style, "italic")
         self.assertEqual(channel.__unicode__(), 'ChannelTest2')
-        self.assertEqual(channel.video_count(), 0)
+        self.assertEqual(channel.video_count, 0)
         self.assertEqual(channel.get_absolute_url(), "/" + channel.slug + "/")
 
         print (
@@ -137,11 +144,14 @@ class ThemeTestCase(TestCase):
 	"""
 
     def test_Theme_null_attribut(self):
-        theme = Theme.objects.get(title="Theme1")
+        theme = Theme.objects.annotate(video_count=Count(Case(
+            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
+            output_field=IntegerField(),
+        ))).get(title="Theme1")
         self.assertFalse(theme.slug == slugify("blabla"))
         self.assertEqual(theme.headband, None)
         self.assertEqual(theme.__unicode__(), "ChannelTest1: Theme1")
-        self.assertEqual(theme.video_count(), 0)
+        self.assertEqual(theme.video_count, 0)
         self.assertEqual(theme.description, None)
         self.assertEqual(
             theme.get_absolute_url(), "/" + theme.channel.slug + "/" + theme.slug + "/")
@@ -198,11 +208,14 @@ class TypeTestCase(TestCase):
 	"""
 
     def test_Type_null_attribut(self):
-        type1 = Type.objects.get(title="Type1")
+        type1 = Type.objects.annotate(video_count=Count(Case(
+            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
+            output_field=IntegerField(),
+        ))).get(title="Type1")
         self.assertFalse(type1.slug == slugify("blabla"))
         self.assertEqual(type1.headband, None)
         self.assertEqual(type1.__unicode__(), "Type1")
-        self.assertEqual(type1.video_count(), 0)
+        self.assertEqual(type1.video_count, 0)
         self.assertEqual(type1.description, None)
 
         print (
@@ -259,11 +272,14 @@ class DisciplineTestCase(TestCase):
 	"""
 
     def test_Discipline_null_attribut(self):
-        discipline = Discipline.objects.get(title="Discipline1")
+        discipline = Discipline.objects.annotate(video_count=Count(Case(
+            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
+            output_field=IntegerField(),
+        ))).get(title="Discipline1")
         self.assertFalse(discipline.slug == slugify("blabla"))
         self.assertEqual(discipline.headband, None)
         self.assertEqual(discipline.__unicode__(), "Discipline1")
-        self.assertEqual(discipline.video_count(), 0)
+        self.assertEqual(discipline.video_count, 0)
         self.assertEqual(discipline.description, None)
 
         print (

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -46,7 +46,7 @@ from django.utils import formats
 from django.utils.http import urlquote
 from django.core.mail import EmailMultiAlternatives
 from django.contrib.sites.shortcuts import get_current_site
-
+from django.db.models import Count, Case, When, IntegerField
 import simplejson as json
 
 from django.core.servers.basehttp import FileWrapper
@@ -94,7 +94,10 @@ def owner_channels_list(request):
 
 
 def channels(request):
-    channels_list = Channel.objects.filter(visible=True)
+    channels_list = Channel.objects.filter(visible=True).annotate(video_count=Count(Case(
+        When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
+        output_field=IntegerField(),
+    )))
     #per_page = request.GET.get('per_page') if request.GET.get('per_page') and request.GET.get('per_page').isdigit() else DEFAULT_PER_PAGE
     per_page = request.COOKIES.get('perpage') if request.COOKIES.get(
         'perpage') and request.COOKIES.get('perpage').isdigit() else DEFAULT_PER_PAGE
@@ -208,7 +211,10 @@ def channel_edit(request, slug_c):
 
 
 def types(request):
-    types_list = Type.objects.all()
+    types_list = Type.objects.all().annotate(video_count=Count(Case(
+        When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
+        output_field=IntegerField(),
+    )))
     #per_page = request.GET.get('per_page') if request.GET.get('per_page') and request.GET.get('per_page').isdigit() else DEFAULT_PER_PAGE
     per_page = request.COOKIES.get('perpage') if request.COOKIES.get(
         'perpage') and request.COOKIES.get('perpage').isdigit() else DEFAULT_PER_PAGE
@@ -230,7 +236,10 @@ def types(request):
 
 def owners(request):
     owners_list = User.objects.filter(pod__in=VIDEOS).order_by(
-        'last_name').distinct()  # User.objects.all()
+        'last_name').distinct().annotate(video_count=Count(Case(
+            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
+            output_field=IntegerField(),
+        )))
     owners_filter = request.GET.get(
         'owners_filter') if request.GET.get('owners_filter') else None
     if owners_filter:
@@ -256,7 +265,10 @@ def owners(request):
 
 
 def disciplines(request):
-    disciplines_list = Discipline.objects.all()
+    disciplines_list = Discipline.objects.all().annotate(video_count=Count(Case(
+        When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
+        output_field=IntegerField(),
+    )))
     #per_page = request.GET.get('per_page') if request.GET.get('per_page') and request.GET.get('per_page').isdigit() else DEFAULT_PER_PAGE
     per_page = request.COOKIES.get('perpage') if request.COOKIES.get(
         'perpage') and request.COOKIES.get('perpage').isdigit() else DEFAULT_PER_PAGE

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -235,11 +235,11 @@ def types(request):
 
 
 def owners(request):
-    owners_list = User.objects.filter(pod__in=VIDEOS).order_by(
+    owners_list = User.objects.filter(pod__is_draft=False, pod__encodingpods__gt=0).order_by(
         'last_name').distinct().annotate(video_count=Count(Case(
             When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
             output_field=IntegerField(),
-        )))
+        ))).prefetch_related("userprofile")
     owners_filter = request.GET.get(
         'owners_filter') if request.GET.get('owners_filter') else None
     if owners_filter:


### PR DESCRIPTION
Bonjour,

J'ai commencé l'optimisation des requêtes sql car nous rencontrons des problèmes de performance suite à la migration de nos contenus de audiovideocast sur pod.

En effet, la page "/videos" utilise 938 requêtes sql pour s'afficher !
Avec les modifications de cette pull request, on est passé à 83 requêtes sql.

En gros :

1) La navbar affiche les utilisateurs avec le nombre de leur cours entre parenthèse. Pour chaque utilisateur, une requête était exécutée pour récupérer ce nombre. Puisque nous avons environ 500 utilisateurs, il y a environ 500 requêtes qui était exécutées. L'utilisation du prefetch related sur l'élément OWNERS de templatetags/list.py a permis de réduire ce chiffre à 18. La navbar étant utilisée sur toutes les pages, les performance en sont fortement impactées. Le "distinct", le "count" et le "is_draft=False" sont vérifiés en python. Je n'ai pas remplacé le "encodingpods__gt=0" car ça générerait encore des requêtes supplémentaires coûteuses et ça me semblait facultatif.

2)  La page "/videos" accède au userprofile de chaque user. Il effectuait donc une requête pour chaque user, donc à nouveau 500 requêtes. L'utilisation du prefetch related dans pods/templatetags/list.py a fortement diminué le nombre de requêtes également.

Il reste en encore des éléments qui posent problème, notamment les fonctions "def video_count" de Discipline, Thème, Channel et Type. En effet, si on a par exemple 50 disciplines, 50 requêtes SQL vont être exécutées uniquement pour récupérer ce chiffre ...

Si on imagine avoir autant de Thème, Channel, et Type, on aurait 200 requêtes SQL d'exécutées.

La page "/videos/" s'affichait en 5,9 seconde. Elle s'affiche désormais en 2,8 secondes, ce qui est un bon début. Mais ça serait bien de descendre en dessous de 2 secondes.

Les tests unitaires passent toujours.

Etes-vous intéressé par ce genre d'optimisation ? En tout cas chez nous c'est vital.

A+

Morgan




