### PR TITLE
Unistra improve sql 2

### DIFF
--- a/pod_project/pods/tests/tests_models.py
+++ b/pod_project/pods/tests/tests_models.py
@@ -33,7 +33,7 @@ from django.test.client import RequestFactory
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from datetime import date, timedelta
 import os
-from django.db.models import Count, Case, When, IntegerField
+from django.db.models import Count
 # Create your tests here.
 """
     test the channel
@@ -63,10 +63,7 @@ class ChannelTestCase(TestCase):
 	"""
 
     def test_Channel_null_attribut(self):
-        channel = Channel.objects.annotate(video_count=Count(Case(
-            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
-            output_field=IntegerField(),
-        ))).get(title="ChannelTest1")
+        channel = Channel.objects.annotate(video_count=Count("pod", distinct=True)).get(title="ChannelTest1")
         self.assertEqual(channel.visible, False)
         self.assertFalse(channel.slug == slugify("blabla"))
         self.assertEqual(channel.color, None)
@@ -85,10 +82,7 @@ class ChannelTestCase(TestCase):
 	"""
 
     def test_Channel_with_attributs(self):
-        channel = Channel.objects.annotate(video_count=Count(Case(
-            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
-            output_field=IntegerField(),
-        ))).get(title="ChannelTest2")
+        channel = Channel.objects.annotate(video_count=Count("pod", distinct=True)).get(title="ChannelTest2")
         self.assertEqual(channel.visible, True)
         channel.color = "Blue"
         self.assertEqual(channel.color, "Blue")
@@ -144,10 +138,7 @@ class ThemeTestCase(TestCase):
 	"""
 
     def test_Theme_null_attribut(self):
-        theme = Theme.objects.annotate(video_count=Count(Case(
-            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
-            output_field=IntegerField(),
-        ))).get(title="Theme1")
+        theme = Theme.objects.annotate(video_count=Count("pod", distinct=True)).get(title="Theme1")
         self.assertFalse(theme.slug == slugify("blabla"))
         self.assertEqual(theme.headband, None)
         self.assertEqual(theme.__unicode__(), "ChannelTest1: Theme1")
@@ -208,10 +199,7 @@ class TypeTestCase(TestCase):
 	"""
 
     def test_Type_null_attribut(self):
-        type1 = Type.objects.annotate(video_count=Count(Case(
-            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
-            output_field=IntegerField(),
-        ))).get(title="Type1")
+        type1 = Type.objects.annotate(video_count=Count("pod", distinct=True)).get(title="Type1")
         self.assertFalse(type1.slug == slugify("blabla"))
         self.assertEqual(type1.headband, None)
         self.assertEqual(type1.__unicode__(), "Type1")
@@ -272,10 +260,7 @@ class DisciplineTestCase(TestCase):
 	"""
 
     def test_Discipline_null_attribut(self):
-        discipline = Discipline.objects.annotate(video_count=Count(Case(
-            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
-            output_field=IntegerField(),
-        ))).get(title="Discipline1")
+        discipline = Discipline.objects.annotate(video_count=Count("pod", distinct=True)).get(title="Discipline1")
         self.assertFalse(discipline.slug == slugify("blabla"))
         self.assertEqual(discipline.headband, None)
         self.assertEqual(discipline.__unicode__(), "Discipline1")

--- a/pod_project/pods/tests/tests_views.py
+++ b/pod_project/pods/tests/tests_views.py
@@ -60,13 +60,7 @@ class ChannelsTestView(TestCase):
     def setUp(self):
         remi = User.objects.create(username="remi")
         i = 1
-        while i <= 15:
-            Channel.objects.create(title="ChannelTest" + str(i), visible=True,
-                                   color="Black", style="italic", description="blabla")
-            i += 1
 
-        t = Theme.objects.create(
-            title="Theme1", channel=Channel.objects.get(id=1))
         other_type = Type.objects.get(id=1)
         media_guard_hash = get_media_guard("remi", 1)
         pod = Pod.objects.create(type=other_type, title="Video2", encoding_status="b", encoding_in_progress=False,
@@ -74,19 +68,25 @@ class ChannelsTestView(TestCase):
                                  allow_downloading=True, view_count=2, description="fl", overview=os.path.join("videos", "remi", media_guard_hash, "1", "overview.jpg"), is_draft=False,
                                  duration=3, infoVideo="videotest", to_encode=False)
         EncodingPods.objects.create(
-            video=pod, encodingType=EncodingType.objects.get(id=1))
-        pod.theme.add(t)
-        pod.channel.add(Channel.objects.get(id=1))
+                video=pod, encodingType=EncodingType.objects.get(id=1))
+        while i <= 15:
+            c = Channel.objects.create(title="ChannelTest" + str(i), visible=True,
+                                   color="Black", style="italic", description="blabla")
+            t = Theme.objects.create(
+                    title="Theme" + str(i), channel=Channel.objects.get(id=i))
+            pod.channel.add(c)
+            pod.theme.add(t)
+            i += 1
         pod.save()
         print(" --->  SetUp of ChannelsTestView : OK !")
 
     def test_channels_with_paginator(self):
-        channels = list(Channel.objects.all())
+        channels = list(Channel.objects.filter(pod__is_draft=False, pod__encodingpods__gt=0).distinct())
         # test when a index of page is a caractere
         response = self.client.get("/channels/?page=a")
         self.assertEqual(response.status_code, 200)
         liste = list(response.context[u"channels"].__dict__["object_list"])
-        paginator = Paginator(Channel.objects.all(), 12)
+        paginator = Paginator(Channel.objects.filter(pod__is_draft=False, pod__encodingpods__gt=0).distinct(), 12)
         self.assertEqual(liste, channels[:12])
 
         self.assertEqual(
@@ -159,7 +159,7 @@ class Owner_channels_listTestView(TestCase):
         self.user = User.objects.get(username="testuser")
         self.user = authenticate(username='testuser', password='hello')
         login = self.client.login(username='testuser', password='hello')
-        channels = list(Channel.objects.filter(owners=self.user))
+        channels = list(Channel.objects.filter(owners=self.user, pod__is_draft=False, pod__encodingpods__gt=0).distinct())
         self.assertEqual(login, True)
         response = self.client.get("/owner_channels_list/")
         self.assertEqual(response.status_code, 200)
@@ -393,7 +393,7 @@ class TypesTestView(TestCase):
         print(" --->  SetUp of TypesTestView : OK !")
 
     def test_types(self):
-        types = list(Type.objects.all())
+        types = list(Type.objects.filter(pod__is_draft=False, pod__encodingpods__gt=0).distinct())
         response = self.client.get("/types/")
         liste = list(response.context[u"types"].__dict__["object_list"])
         self.assertEqual(response.status_code, 200)
@@ -508,7 +508,7 @@ class DisciplinesTestView(TestCase):
         print(" --->  SetUp of DisciplinesTestView : OK !")
 
     def test_disciplines(self):
-        disciplines = list(Discipline.objects.all())
+        disciplines = list(Discipline.objects.filter(pod__is_draft=False, pod__encodingpods__gt=0).distinct())
         response = self.client.get("/disciplines/")
         liste = list(response.context[u"disciplines"].__dict__["object_list"])
         self.assertEqual(response.status_code, 200)

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -46,7 +46,7 @@ from django.utils import formats
 from django.utils.http import urlquote
 from django.core.mail import EmailMultiAlternatives
 from django.contrib.sites.shortcuts import get_current_site
-from django.db.models import Count, Case, When, IntegerField
+from django.db.models import Count
 import simplejson as json
 
 from django.core.servers.basehttp import FileWrapper
@@ -94,10 +94,9 @@ def owner_channels_list(request):
 
 
 def channels(request):
-    channels_list = Channel.objects.filter(visible=True).annotate(video_count=Count(Case(
-        When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
-        output_field=IntegerField(),
-    )))
+    channels_list = Channel.objects.filter(
+        visible=True, pod__is_draft=False, pod__encodingpods__gt=0
+    ).distinct().annotate(video_count=Count("pod", distinct=True))
     #per_page = request.GET.get('per_page') if request.GET.get('per_page') and request.GET.get('per_page').isdigit() else DEFAULT_PER_PAGE
     per_page = request.COOKIES.get('perpage') if request.COOKIES.get(
         'perpage') and request.COOKIES.get('perpage').isdigit() else DEFAULT_PER_PAGE
@@ -211,10 +210,9 @@ def channel_edit(request, slug_c):
 
 
 def types(request):
-    types_list = Type.objects.all().annotate(video_count=Count(Case(
-        When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
-        output_field=IntegerField(),
-    )))
+    types_list = Type.objects.filter(
+        pod__is_draft=False, pod__encodingpods__gt=0
+    ).distinct().annotate(video_count=Count("pod", distinct=True))
     #per_page = request.GET.get('per_page') if request.GET.get('per_page') and request.GET.get('per_page').isdigit() else DEFAULT_PER_PAGE
     per_page = request.COOKIES.get('perpage') if request.COOKIES.get(
         'perpage') and request.COOKIES.get('perpage').isdigit() else DEFAULT_PER_PAGE
@@ -235,11 +233,10 @@ def types(request):
 
 
 def owners(request):
-    owners_list = User.objects.filter(pod__is_draft=False, pod__encodingpods__gt=0).order_by(
-        'last_name').distinct().annotate(video_count=Count(Case(
-            When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
-            output_field=IntegerField(),
-        ))).prefetch_related("userprofile")
+    owners_list = User.objects.filter(
+        pod__is_draft=False, pod__encodingpods__gt=0
+    ).order_by(
+        'last_name').distinct().annotate(video_count=Count("pod", distinct=True)).prefetch_related("userprofile")
     owners_filter = request.GET.get(
         'owners_filter') if request.GET.get('owners_filter') else None
     if owners_filter:
@@ -265,10 +262,9 @@ def owners(request):
 
 
 def disciplines(request):
-    disciplines_list = Discipline.objects.all().annotate(video_count=Count(Case(
-        When(pod__is_draft=False, pod__encodingpods__gt=0, then=1),
-        output_field=IntegerField(),
-    )))
+    disciplines_list = Discipline.objects.filter(
+        pod__is_draft=False, pod__encodingpods__gt=0
+    ).distinct().annotate(video_count=Count("pod", distinct=True))
     #per_page = request.GET.get('per_page') if request.GET.get('per_page') and request.GET.get('per_page').isdigit() else DEFAULT_PER_PAGE
     per_page = request.COOKIES.get('perpage') if request.COOKIES.get(
         'perpage') and request.COOKIES.get('perpage').isdigit() else DEFAULT_PER_PAGE

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -74,7 +74,7 @@ def get_pagination(page, paginator):
 
 @login_required
 def owner_channels_list(request):
-    channels_list = request.user.owners_channels.all()
+    channels_list = request.user.owners_channels.all().annotate(video_count=Count("pod", distinct=True))
     per_page = request.COOKIES.get('perpage') if request.COOKIES.get(
         'perpage') and request.COOKIES.get('perpage').isdigit() else DEFAULT_PER_PAGE
     paginator = Paginator(channels_list, per_page)


### PR DESCRIPTION
Salut
On a détecté un bug avec les annotations Count. Elles comptaient le nombre d'encoding à la place du nombre de pod.
Du coup je les ai corrigé, le chiffre qui s'affiche est maintenant juste.

Pour ce faire, j'ai du filtrer les channels, disciplines, thèmes et types qui s'affichent sur la page d'accueil.
Comme pour les utilisateurs, seul les éléments qui contiennent au moins une vidéo non brouillon et avec un encoding s'afficheront. J'espère que ça vous convient.

Ça a également encore amélioré le temps de réponse.
J'ai adapté les tests unitaires.

Attend un peu avant de merge, je te confirmerai ça ici. L'équipe projet fait des tests cette après-midi sur ces correctifs.

Désolé pour le dérangement.



Merci