### PR TITLE
Feature: content order on same day

### DIFF
--- a/pod_project/core/models.py
+++ b/pod_project/core/models.py
@@ -211,7 +211,7 @@ class Video(models.Model):
         ordering = ['-date_added', '-id']
         get_latest_by = 'date_added'
         verbose_name = _("video")
-        verbose_name_plural = _("video")
+        verbose_name_plural = _("videos")
         abstract = True
 
     def __unicode__(self):

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -314,10 +314,6 @@ class Pod(Video):
 
     _encoding_user_email_data = None
 
-    class Meta:
-        verbose_name = _("Video")
-        verbose_name_plural = _("Videos")
-
     def __unicode__(self):
         return u"Titre:%s - Prop:%s - Date:%s" % (self.title, self.owner, self.date_added)
 

--- a/pod_project/pods/templatetags/list.py
+++ b/pod_project/pods/templatetags/list.py
@@ -193,7 +193,7 @@ def get_last_videos():
     return {
         'videos': Pod.objects.filter(**filter_args).exclude(
             channel__visible=0).order_by(
-            "-date_added").distinct()[:HOMEPAGE_NBR_CONTENTS_SHOWN],
+            '-date_added', '-id').distinct()[:HOMEPAGE_NBR_CONTENTS_SHOWN],
         'DEFAULT_IMG': settings.DEFAULT_IMG
     }
 

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -318,8 +318,13 @@ def owner_videos_list(request):
 
     order_by = request.COOKIES.get('orderby') if request.COOKIES.get(
         'orderby') else "order_by_-date_added"
-    videos_list = videos_list.order_by(
-        "%s" % replace(order_by, "order_by_", ""))
+    if order_by == 'order_by_date_added':
+        videos_list = videos_list.order_by('date_added', 'id')
+    elif order_by == 'order_by_-date_added':
+        videos_list = videos_list.order_by('-date_added', '-id')
+    else:
+        videos_list = videos_list.order_by(
+            "%s" % replace(order_by, "order_by_", ""))
 
     paginator = Paginator(videos_list, per_page)
     page = request.GET.get('page')
@@ -351,8 +356,13 @@ def favorites_videos_list(request):
 
     order_by = request.COOKIES.get('orderby') if request.COOKIES.get(
         'orderby') else "order_by_-date_added"
-    videos_list = videos_list.order_by(
-        "%s" % replace(order_by, "order_by_", ""))
+    if order_by == 'order_by_date_added':
+        videos_list = videos_list.order_by('date_added', 'id')
+    elif order_by == 'order_by_-date_added':
+        videos_list = videos_list.order_by('-date_added', '-id')
+    else:
+        videos_list = videos_list.order_by(
+            "%s" % replace(order_by, "order_by_", ""))
 
     paginator = Paginator(videos_list, per_page)
     page = request.GET.get('page')
@@ -430,8 +440,14 @@ def videos(request):
 
     order_by = request.COOKIES.get('orderby') if request.COOKIES.get(
         'orderby') else "order_by_-date_added"
-    videos_list = videos_list.order_by(
-        "%s" % replace(order_by, "order_by_", ""))
+    if order_by == 'order_by_date_added':
+        videos_list = videos_list.order_by('date_added', 'id')
+    elif order_by == 'order_by_-date_added':
+        # Already defined in model, so…
+        pass
+    else:
+        videos_list = videos_list.order_by(
+            "%s" % replace(order_by, "order_by_", ""))
 
     per_page = request.COOKIES.get('perpage') if request.COOKIES.get(
         'perpage') and request.COOKIES.get(


### PR DESCRIPTION
Permet de présenter les contenus triés par « id » à l'intérieur de la même « date_added », pour obtenir un pseudo ordre chronologique des contenus créés le même jour, en correspondance avec la meta « ordering » du modèle.

Notre besoin étant juste l'obtention d'un ordre d'affichage reflétant celui de création dans un contexte de contenus pré-existants, l'alternative consistant à passer le champ « date_added » en DATETIME a été rapidement écartée…
