### PR TITLE
Settings upgrade

### DIFF
--- a/pod_project/pod_project/settings_local-sample.py
+++ b/pod_project/pod_project/settings_local-sample.py
@@ -77,7 +77,7 @@ DATABASES = {
         'PASSWORD': 'test',
         'HOST': '',
         'PORT': '',
-        'OPTIONS': {'init_command': 'SET storage_engine=INNODB;'}
+        'OPTIONS': {'init_command': 'SET default_storage_engine=INNODB;'}
     }
 }
 """
@@ -350,6 +350,7 @@ USE_XHR_FORM_UPLOAD = 1
 #
 ALLOW_VISIBILITY_SETTING_TO_CHANNEL_OWNERS = 1
 
+
 ##
 # Enable is_360 field in video upload form:
 #
@@ -359,6 +360,7 @@ ALLOW_VISIBILITY_SETTING_TO_CHANNEL_OWNERS = 1
 #
 SHOW_IS_360_IN_FORM_UPLOAD = 1
 
+
 ##
 # REMOVE VIDEO SOURCE FILE ON DELETE:
 #
@@ -366,6 +368,7 @@ SHOW_IS_360_IN_FORM_UPLOAD = 1
 #   - when true, the video file uploaded is removed when video was deleted
 #
 REMOVE_VIDEO_FILE_SOURCE_ON_DELETE = True
+
 
 ##
 # Content reporting:
@@ -434,6 +437,7 @@ RECORDER_SALT = 'a.string.used.as.salt'
 #   if set it's used for download and encoding test
 # HTTP_PROXY = 'http://localhost:3128/'
 
+
 ##
 # Enable RSS feed and ATOM feed on channels and search results
 #
@@ -443,6 +447,7 @@ RECORDER_SALT = 'a.string.used.as.salt'
 RSS = False
 ATOM_HD = False
 ATOM_SD = False
+
 
 # Encode with Celery
 #--------------------
@@ -473,13 +478,15 @@ ATOM_SD = False
 # ENCODE_VIDEO = encode_video
 
 
+##
+# Video in draft mode can be shared
+#
+USE_PRIVATE_VIDEO = False
 
 
 ##
-# Video in draft mode can be shared
-USE_PRIVATE_VIDEO = False
-
 # H5P relative parameters
+#
 H5P_ENABLED = False                                     # Active the module or not
 H5P_VERSION = '7.x'                                     # Current version of H5P module
 H5P_DEV_MODE = 0                                        # Active the development mode or not


### PR DESCRIPTION
Remplacement de « storage_engine » (dépréciée depuis MySQL 5.7.5) par « default_storage_engine » (introduite par MySQL 5.5.3).

https://code.djangoproject.com/ticket/26121
https://docs.djangoproject.com/en/1.8/ref/databases/#creating-your-tables

À noter que ce couple clé / valeur de DATABASES['default']['OPTIONS'] ne sert que lors de la création des tables, donc lors de l'installation et de mises à jour effectuant des créations de tables (voir second lien ci-dessus) :

> This sets the default storage engine upon connecting to the database. After your tables have been created, you should remove this option as it adds a query that is only needed during table creation to each database connection.

On peut donc le commenter en usage normal pour économiser quelques requêtes…