### PR TITLE
Feature: filtering owners in menubar

### DIFF
--- a/pod_project/pod_project/settings_local-sample.py
+++ b/pod_project/pod_project/settings_local-sample.py
@@ -272,6 +272,15 @@ HOMEPAGE_SHOWS_RESTRICTED = True
 
 
 ##
+# Main menu settings:
+#
+# Do not show inactive users in “Owners” main menu list.
+MENUBAR_HIDE_INACTIVE_OWNERS = False
+# Show only staff users in “Owners” main menu list.
+MENUBAR_SHOW_STAFF_OWNERS_ONLY = False
+
+
+##
 # WebM video encoding activation:
 #
 #   True: video files will be available in both mp4 and WebM formats,

--- a/pod_project/pods/context_processors.py
+++ b/pod_project/pods/context_processors.py
@@ -22,9 +22,24 @@ voir http://www.gnu.org/licenses/
 from pods.models import Channel, Type, Discipline, Theme
 from django.contrib.auth.models import User
 from django.db.models import Count, Prefetch
+from django.conf import settings
+
+
+MENUBAR_HIDE_INACTIVE_OWNERS = getattr(
+        settings, 'MENUBAR_HIDE_INACTIVE_OWNERS', False)
+MENUBAR_SHOW_STAFF_OWNERS_ONLY = getattr(
+        settings, 'MENUBAR_SHOW_STAFF_OWNERS_ONLY', False)
 
 
 def items_menu_header(request):
+    owners_filter_args = {
+            'pod__is_draft': False,
+            'pod__encodingpods__gt': 0,
+        }
+    if MENUBAR_HIDE_INACTIVE_OWNERS:
+        owners_filter_args['is_active'] = True
+    if MENUBAR_SHOW_STAFF_OWNERS_ONLY:
+        owners_filter_args['is_staff'] = True
     return {
         'CHANNELS': Channel.objects.filter(
             visible=True, pod__is_draft=False, pod__encodingpods__gt=0
@@ -42,9 +57,8 @@ def items_menu_header(request):
         'DISCIPLINES': Discipline.objects.filter(
             pod__is_draft=False, pod__encodingpods__gt=0
         ).distinct().annotate(video_count=Count("pod", distinct=True)),
-        'OWNERS': User.objects.filter(
-            pod__is_draft=False, pod__encodingpods__gt=0
-        ).order_by('last_name').distinct().annotate(
-            video_count=Count("pod", distinct=True)).prefetch_related("userprofile"),
-        'H5P_ENABLED': django_settings.H5P_ENABLED
+        'OWNERS': User.objects.filter(**owners_filter_args).order_by(
+            'last_name').distinct().annotate(video_count=Count(
+                "pod", distinct=True)).prefetch_related("userprofile"),
+        'H5P_ENABLED': settings.H5P_ENABLED
     }

--- a/pod_project/pods/context_processors.py
+++ b/pod_project/pods/context_processors.py
@@ -19,9 +19,7 @@ GNU General Public Licence
 avec ce programme. Si ce n'est pas le cas,
 voir http://www.gnu.org/licenses/
 """
-from pods.models import Pod, Channel, Type, Discipline, Theme
-from django.contrib.sites.models import Site
-from django.conf import settings as django_settings
+from pods.models import Channel, Type, Discipline, Theme
 from django.contrib.auth.models import User
 from django.db.models import Count, Prefetch
 


### PR DESCRIPTION
Cette PR ajoute la possibilité de ne pas afficher les utilisateurs « non staff » dans la liste de propriétaires de contenu (« Utilisateurs ») de la barre de menu principale (1), ainsi que - tant qu'à faire - ceux ayant été désactivés (comptes locaux uniquement, l'authentification CAS impliquant l'activation du compte) (2).

À Nice nous avons beaucoup de productions étudiantes, les enseignants et personnels fournissant du contenu se trouvent noyés dans la masse. Activer cette option (1) nous permet :
- de mettre l'accent sur les enseignants et personnels de l'Université,
- d'éviter les menus déroulants « Utilisateurs » trop longs.

Au cas où cela intéresserait d'autres institutions utilisatrices de Pod.

> 1 : MENUBAR_SHOW_STAFF_OWNERS_ONLY
> 2 : MENUBAR_HIDE_INACTIVE_OWNERS