### PR TITLE
Drclockwork/bugfix_if_celery_is_not_used

### DIFF
--- a/pod_project/pod_project/__init__.py
+++ b/pod_project/pod_project/__init__.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+from django.conf import settings
 
+# If celery is used.
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
-from .celery import app as celery_app
+if getattr(settings, 'ENCODE_VIDEO', False):
+	from .celery import app as celery_app
 
-__all__ = ['celery_app']
+	__all__ = ['celery_app']

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -467,7 +467,7 @@ def launch_encode(sender, instance, created, **kwargs):
         instance.to_encode = False
         instance.encoding_in_progress = True
         instance.save()
-        if settings.CELERY_TO_ENCODE:
+        if hasattr(settings, 'CELERY_TO_ENCODE'):
             logger.error(
                 'CELERY_TO_ENCODE setting is now deprecated in flavor of ENCODE_VIDEO')
 


### PR DESCRIPTION
- use hasattr() instead of settings.CELERY_TO_ENCODE
- check if ENCODE_VIDEO is set before import the celery app