### PR TITLE
drclockwork/bugfix_download_video_unavailable_resolution

### DIFF
--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -765,13 +765,18 @@ def download_video(video, get_request):
     format = "video/mp4" if "video" in video.get_mediatype() else "audio/mp3"
     resolution = get_request.get(
         'resolution') if get_request.get('resolution') else 240
-    filename = EncodingPods.objects.get(
-        video=video, encodingType__output_height=resolution, encodingFormat=format).encodingFile.path
-    wrapper = FileWrapper(file(filename))
-    response = HttpResponse(wrapper, content_type=format)
-    response['Content-Length'] = os.path.getsize(filename)
-    response['Content-Disposition'] = 'attachment; filename="%s_%s.%s"' % (
-        video.slug, resolution, format.split("/")[1])
+
+    if int(resolution) in video.get_all_encoding_height():
+        filename = EncodingPods.objects.get(
+            video=video, encodingType__output_height=resolution, encodingFormat=format).encodingFile.path
+        wrapper = FileWrapper(file(filename))
+        response = HttpResponse(wrapper, content_type=format)
+        response['Content-Length'] = os.path.getsize(filename)
+        response['Content-Disposition'] = 'attachment; filename="%s_%s.%s"' % (
+            video.slug, resolution, format.split("/")[1])
+    else:
+        raise PermissionDenied
+
     return response
 
 


### PR DESCRIPTION
Now when a user tries to download a video with a bad resolution it correctly displays an error